### PR TITLE
Arcade control uses the right joystick, not left

### DIFF
--- a/content/getting-started/index.md
+++ b/content/getting-started/index.md
@@ -105,8 +105,8 @@ void operatorControl() {
   int power;
   int turn;
 	while (1) {
-		power = joystickGetAnalog(1, 2); // vertical axis on left joystick
-		turn  = joystickGetAnalog(1, 1); // horizontal axis on left joystick
+		power = joystickGetAnalog(1, 2); // vertical axis on right joystick
+		turn  = joystickGetAnalog(1, 1); // horizontal axis on right joystick
 		motorSet(2, power + turn); // set left wheels
 		motorSet(3, power - turn); // set right wheels
 		delay(20);


### PR DESCRIPTION
Corrected the joystick description in the arcade control example.