### PR TITLE
Fix broken links by adding subfolders to path

### DIFF
--- a/v5/extended/apix.rst
+++ b/v5/extended/apix.rst
@@ -406,4 +406,4 @@ sem_t
 
   typedef void* sem_t;
 
-A `semaphore <../tutorials/multitasking>`_.
+A `semaphore <../tutorials/topical/multitasking>`_.

--- a/v5/getting-started/new-users.rst
+++ b/v5/getting-started/new-users.rst
@@ -51,19 +51,19 @@ I know C/C++, now how do I use PROS?
 ------------------------------------
 
 The PROS tutorials are designed to show the application of C/C++ programming
-to a PROS project. The `Programming the Clawbot <../tutorials/clawbot.html>`_
+to a PROS project. The `Programming the Clawbot <../tutorials/walkthrough/clawbot.html>`_
 tutorial is a great place to start, as it
 goes through every step of putting together a sample PROS project. Once
 you are ready to branch out and create your own custom project, looking
 through the following tutorials is recommended:
 
--  `PROS Project Structure <../tutorials/project-structure.html>`_
+-  `PROS Project Structure <../tutorials/general/project-structure.html>`_
 
--  `Uploading Code <../tutorials/uploading.html>`_
+-  `Uploading Code <../tutorials/walkthrough/uploading.html>`_
 
--  `Debugging <../tutorials/debugging.html>`_
+-  `Debugging <../tutorials/general/debugging.html>`_
 
 -  `Coding FAQs <./faq.html>`_
 
-And then you can find tutorials for specific subjects from `the ADI <../tutorials/adi.html>`_
-to `tasks and multithreading <../tutorials/multitasking.html>`_ as well.
+And then you can find tutorials for specific subjects from `the ADI <../tutorials/topical/adi.html>`_
+to `tasks and multithreading <../tutorials/topical/multitasking.html>`_ as well.

--- a/v5/tutorials/general/coding-faq.rst
+++ b/v5/tutorials/general/coding-faq.rst
@@ -32,7 +32,7 @@ Run-Time Issues
     equal priority to the blocking task will still run while lower priority tasks
     will not. This scenario is also known as
     `starvation <https://en.wikipedia.org/wiki/Starvation_(computer_science)>`_.
-    See `Tasks/Multithreading </tutorials/multitasking>`_ for more information.
+    See `Tasks/Multithreading </tutorials/topical/multitasking>`_ for more information.
 
  * **VEX LCD updates very slowly or is "frozen":**
     A task is not waiting using `delay <../../api/c/rtos.html#delay>`_ or
@@ -82,7 +82,7 @@ Run-Time Issues
 
  * `printf <printf_>`_ **doesn't work**:
     `printf <http://www.cplusplus.com/reference/cstdio/printf/>`_ prints
-    information over a serial connection (`Debugging <../tutorials/debugging>`_),
+    information over a serial connection (`Debugging <../tutorials/general/debugging>`_),
     not to the VEX LCD. To print to the LCD, use `lcd_print <../../api/c/llemu.html#lcd-print>`_
     instead.
 

--- a/v5/tutorials/general/debugging.rst
+++ b/v5/tutorials/general/debugging.rst
@@ -18,7 +18,7 @@ To view a robot's output, there are two officially supported methods:
 
    Running ``pros terminal`` on the command line will open an output
    stream from a robot connected over direct USB connection, VEXnet, or
-   `JINX <./tutorials/jinx.html>`_.
+   `JINX <./tutorials/topical/jinx.html>`_.
 
 2. From within Atom:
 


### PR DESCRIPTION
Hey guys,

Love the v5 documentation.  Noticed you added some subfolders to the tutorials section a while back which caused some links to break.  Hope this might help?

Also - massive thanks to the gentleman who helped troubleshoot my PROS install for the software stations at VEX Worlds.  We got exactly what we needed, and he was super helpful and gracious about it.  :)