### PR TITLE
Add LVGL tutorial

### DIFF
--- a/v5/tutorials/topical/display.rst
+++ b/v5/tutorials/topical/display.rst
@@ -8,7 +8,8 @@ LVGL is a full-featured C graphics library (it's accessible in C++ projects too 
 The first step to getting started with LVGL is to include ``apix.h`` in your ``main.h`` file or other header files.
 This includes the full LVGL feature set as described in their documentation: https://littlevgl.com/basics
 
-From there, you can follow along with any of the LVGL tutorials (such as the one linked above).
+From there, you can follow along with any of the LVGL tutorials (such as the one linked above). There is no need
+to initialize LVGL, you can simply start creating objects.
 
 .. warning:: LVGL code should be executed in one of the main PROS tasks (``initialize()``, ``autonomous()``,
              or ``opcontrol()``). Running LVGL code in a user-created task will fail to change the display.

--- a/v5/tutorials/topical/display.rst
+++ b/v5/tutorials/topical/display.rst
@@ -12,3 +12,5 @@ From there, you can follow along with any of the LVGL tutorials (such as the one
 to initialize LVGL, you can simply start creating objects.
 
 .. note:: Custom LVGL code cannot be displayed at the same time as the `LLEMU <./llemu.html>`_.
+          As a result, you must remove the LLEMU code that is present in ``initialize.cpp`` by default in a 
+          new project.

--- a/v5/tutorials/topical/display.rst
+++ b/v5/tutorials/topical/display.rst
@@ -11,5 +11,4 @@ This includes the full LVGL feature set as described in their documentation: htt
 From there, you can follow along with any of the LVGL tutorials (such as the one linked above). There is no need
 to initialize LVGL, you can simply start creating objects.
 
-.. warning:: LVGL code should be executed in one of the main PROS tasks (``initialize()``, ``autonomous()``,
-             or ``opcontrol()``). Running LVGL code in a user-created task will fail to change the display.
+.. note:: Custom LVGL code cannot be displayed at the same time as the `LLEMU <./llemu.html>`_.

--- a/v5/tutorials/topical/display.rst
+++ b/v5/tutorials/topical/display.rst
@@ -1,0 +1,14 @@
+=======================
+V5 Brain Display (LVGL)
+=======================
+
+Interacting with the touchscreen on the V5 Brain is made possible through `LVGL <https://littlevgl.com>`_.
+LVGL is a full-featured C graphics library (it's accessible in C++ projects too under the same API).
+
+The first step to getting started with LVGL is to include ``apix.h`` in your ``main.h`` file or other header files.
+This includes the full LVGL feature set as described in their documentation: https://littlevgl.com/basics
+
+From there, you can follow along with any of the LVGL tutorials (such as the one linked above).
+
+.. warning:: LVGL code should be executed in one of the main PROS tasks (``initialize()``, ``autonomous()``,
+             or ``opcontrol()``). Running LVGL code in a user-created task will fail to change the display.

--- a/v5/tutorials/topical/llemu.rst
+++ b/v5/tutorials/topical/llemu.rst
@@ -128,3 +128,6 @@ is pressed.
            pros::lcd::initialize();
            pros::lcd::register_btn0_cb(on_center_button);
          }
+
+
+.. note:: Custom LVGL code cannot be displayed at the same time as LLEMU.


### PR DESCRIPTION
Putting too much information in an LVGL tutorial is redundant with their own docs, but it's probably worth adding a tutorial for it to help point users towards the LVGL site (compared to the single link in the extended API currently), since so many users are asking about it.

I think the main goal is to help redirect users to LVGL's site as opposed to explaining the ins and outs of the library ourselves, but I'm definitely open to suggestions on that.