### PR TITLE
Admonitions for links to single docs

### DIFF
--- a/v5/index.rst
+++ b/v5/index.rst
@@ -64,23 +64,33 @@ Welcome to the PROS Documentation!
 
 If this is your first time using PROS, it is recommended that you check out one of the **Getting Started** tutorials:
 
-:doc:`/getting-started/index`
+.. admonition:: Getting Started
+
+                :doc:`/getting-started/index`
 
 For topical tutorials on everything from the :doc:`./tutorials/topical/adi` to :doc:`./tutorials/walkthrough/uploading`,
 check out the **Tutorial** section:
 
-:doc:`/tutorials/index`
+.. admonition:: Tutorials
+
+                :doc:`/tutorials/index`
 
 And for documentation on using the PROS **API**, see the **API** section:
 
-:doc:`/api/index`
+.. admonition:: API
+
+                :doc:`/api/index`
 
 We're proud to support **OkapiLib**, a library designed to make it easier to incorporate complex functionality
 in your PROS project. For documentation on OkapiLib, see its Docs section:
 
-:doc:`okapi/index`
+.. admonition:: OkapiLib
+
+                :doc:`okapi/index`
 
 Additional features of FreeRTOS that are intended for **advanced users** can be found in the `Extended API <./extended/apix.html>`_.
 Tutorials on these features can be found in the **Extended** section:
 
-:doc:`./extended/index`
+.. admonition:: Extended API
+
+                :doc:`./extended/index`


### PR DESCRIPTION
<img width="960" alt="newlinks" src="https://user-images.githubusercontent.com/16109996/45240472-d1e46b80-b2b6-11e8-8baa-408242015a4c.png">

This seems like it would look nicer and stand out more than the current option: https://pros.cs.purdue.edu/v5/index.html

If we're good with the styling, I'll do this for the other home pages (API home, Cortex Home, etc.)