### PR TITLE
cortex/tutorials: fixed typo

### DIFF
--- a/cortex/tutorials/known-issues.rst
+++ b/cortex/tutorials/known-issues.rst
@@ -76,7 +76,7 @@ follows:
 
    Diagram courtesy of VEX Robotics.
 
-Both wired and wirless (VEXnet 1.0 & 2.0) are supported.
+Both wired and wireless (VEXnet 1.0 & 2.0) are supported.
 
 Terminal doesn't show up!
 -------------------------


### PR DESCRIPTION
Fixed minor typo in cortex/tutorials/known-issues.rst
Changed ```wirless``` to ```wireless```

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>