### PR TITLE
Order Okapi Walkthrough Tuts

### DIFF
--- a/v5/okapi/tutorials/index.rst
+++ b/v5/okapi/tutorials/index.rst
@@ -22,7 +22,11 @@ process of writing an OkapiLib program.
    :glob:
    :titlesonly:
 
-   ./walkthrough/*
+   ./walkthrough/getting-started
+   ./walkthrough/clawbot
+   ./walkthrough/lift
+   ./walkthrough/autonomous-movement-basic
+   ./walkthrough/autonomous-movement-async
 
 Topical Tutorials
 =================


### PR DESCRIPTION
From [this forum post](https://www.vexforum.com/t/okapilib-help/56982), I took a look at the tutorials page and saw that the order of tutorials wasn't that great. You probably want to start at "Getting started", then look at "clawbot", and so on.

Tradeoff is that you're gonna have to manually include future walkthrough tutorials, but at least they'll be an order that's easier for someone taking a first look at Okapi to get a grasp on what's going on.