### PR TITLE
Fixed PROS 2 download link

### DIFF
--- a/home/_templates/index.html
+++ b/home/_templates/index.html
@@ -106,7 +106,7 @@
           </div>
           <div class="section_content">
             <div class="buy_content text-center">
-               <a id="pros2-dl-link" href="https://github.com/purduesigbots/pros/releases/latest" class="buy_btn">DOWNLOAD PROS FOR CORTEX</a>
+               <a id="pros2-dl-link" href="https://github.com/purduesigbots/pros/releases/tag/2.12.2" class="buy_btn">DOWNLOAD PROS FOR CORTEX</a>
             </div>
          </div>
       </section>


### PR DESCRIPTION
Changed PROS 2 download link to point to the last PROS 2 release, since the [purduesigbots/pros](https://github.com/purduesigbots/pros/) repo now includes PROS 3 releases too