### PR TITLE
Update ADI tutorial

### DIFF
--- a/v5/tutorials/topical/adi.rst
+++ b/v5/tutorials/topical/adi.rst
@@ -197,7 +197,7 @@ An example of Line Tracker use:
            pros::ADILineSensor sensor (LINE_TRACKER_PORT);
            pros::Motor motor (MOTOR_PORT);
            // Arbitrarily set the threshold for a line at 2000 quid
-           while(sensor.get_value < 2000) {
+           while(sensor.get_value() < 2000) {
              // drive forward until a line is hit
              motor = 127;
              delay(50);


### PR DESCRIPTION
Fixes an issue in the ADI page where the code for the line tracker had the line
`while(sensor.get_value < 2000) {`
when the correct line is
`while(sensor.get_value() < 2000) {`

resolves #116 