### PR TITLE
Ignore venv and sphinx-tabs dirty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 .vscode
 myenv/
 pros-docs.tar.gz
+venv/

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,4 @@
 	path = sphinx-tabs
 	url = https://github.com/purduesigbots/sphinx-tabs.git
 	branch = master
+	ignore = dirty


### PR DESCRIPTION
This PR adds `venv` to the gitignore and amends gitmodules so it ignores a dirty sphinx-tabs, which occurs when you build.