### PR TITLE
updating installation documentation to python 3.7

### DIFF
--- a/v5/getting-started/linux.rst
+++ b/v5/getting-started/linux.rst
@@ -5,17 +5,17 @@ Installing on Linux
 Installing the toolchain
 ------------------------
 
-1. Follow the instructions found `here <https://launchpad.net/~team-gcc-arm-embedded/+archive/ubuntu/ppa>`_ to add and install the latest version of the GNU Arm Embedded toolchain.
+1. If you are using a Debian-based distribution of Linux of version >18.04, you can find the toolchain `here <https://www.ubuntuupdates.org/package/core/disco/universe/base/gcc-arm-none-eabi>`_.
 
-.. note:: If you are using a Debian-based distribution of Linux of version >18.04, you can find the toolchain `here <https://www.ubuntuupdates.org/package/core/disco/universe/base/gcc-arm-none-eabi>`_.
+.. note:: If you are using and older Debian-based distrobution of Linux the instructions found `here <https://launchpad.net/~team-gcc-arm-embedded/+archive/ubuntu/ppa>`_ to add and install the latest version of the GNU Arm Embedded toolchain.
 
 .. note:: If you are using a non-Debian-based distribution of Linux, check your favorite package repository for an updated version of the toolchain. The main requirement is that you get one that uses GCC version 7.2 or greater.
 
 Installing the CLI
 ------------------
 
-1. If you do not already have one installed, install a version of Python greater than or equal to 3.6
-2. Check the latest version of the PROS CLI on `our releases page <https://github.com/purduesigbots/pros-cli3/releases/latest>`_, and run :code:`python3.6 -m pip install --user https://github.com/purduesigbots/pros-cli/releases/download/3.X.X/pros_cli_v5-3.X.X-py3-none-any.whl`, replacing the number after 'python' with the version you installed and the Xs with the numbers you found before. If you wish to install for all users, run the command with :code:`sudo` and remove the :code:`--user` flag.
+1. If you do not already have one installed, install a version of Python greater than or equal to 3.6 (3.7 recommended)
+2. Check the latest version of the PROS CLI on `our releases page <https://github.com/purduesigbots/pros-cli3/releases/latest>`_, and run :code:`python3.7 -m pip install --user https://github.com/purduesigbots/pros-cli/releases/download/3.1.4/pros_cli_v5-3.1.4-py3-none-any.whl`, replacing the numbers after 'python' with the version you installed and the X.X.Xs with the numbers you found before. If you wish to install for all users, run the command with :code:`sudo` and remove the :code:`--user` flag.
 3. Run :code:`prosv5 --version` to verify the CLI was installed correctly. If the command doesn't work, try restarting your machine.
 
 Installing the Editor


### PR DESCRIPTION
Since this file was updated python 3.7 has come out, and is now standard. Therefore, making a couple simple changes makes it much easier to install. 
Making a code block and changing the numbers to Xs makes it more confusing rather than putting the latest numbers in and then saying if there is more recent version then use replace the numbers from this link.