### PR TITLE
update homepage

### DIFF
--- a/home/_templates/index.html
+++ b/home/_templates/index.html
@@ -49,7 +49,7 @@
          <div class="container main">
             <div class="fullbg_bigtxt"><img src="_static/img/pros-tux.png" alt="PROS"></div>
             <div class="fullbg_smalltxt">
-               Open Source C/C++ Development for VEX Cortex and the Upcoming v5 Microcontroller<br/>
+               Open Source C/C++ Development for VEX V5 and VEX Cortex<br/>
                <div class ="fullbg_btn pros-bounce">
                   <a href="#about"><span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span></a>
                </div>
@@ -94,20 +94,15 @@
          <div class="big_title">
             <div class="big_title_txt montserrat_font">GET STARTED <span class="text_color">NOW</span></div>
             <div class="text_und_big_title">
-               After installing PROS, read <a href="cortex/getting-started/index.html">Getting Started</a> for an introduction to PROS. <br/>
-               Then, refer to the <a href="cortex/tutorials/index.html">tutorials</a> or <a href="cortex/api/index.html">API documentation</a>.
+               After installing PROS, check out the <a href="v5/tutorials/index.html">tutorials</a> for an introduction to the ecosystem and the <a href="v5/api/index.html">API documentation</a> for more detailed information.
             </div>
             <div class="big_title_txt_separ background_color"></div>
          </div>
          <div class="section_content">
             <div class="buy_content text-center">
-                <a id="pros3-dl-link" href="https://github.com/purduesigbots/pros-cli3/releases" class="buy_btn">DOWNLOAD PROS FOR V5</a>
+                <a id="pros3-dl-link" href="v5/getting-started/" class="buy_btn">GETTING STARTED</a>
              </div>
           </div>
-          <div class="section_content">
-            <div class="buy_content text-center">
-               <a id="pros2-dl-link" href="https://github.com/purduesigbots/pros/releases/tag/2.12.2" class="buy_btn">DOWNLOAD PROS FOR CORTEX</a>
-            </div>
          </div>
       </section>
       <!-- Features
@@ -127,7 +122,7 @@
                      OPEN SOURCE
                   </div>
                   <div class="service_p">
-                     All PROS development is open sourced and available for the community to inspect.
+                     All PROS development is open source and available for the community to inspect.
                      We believe that sharing source improves PROS through community contributions and allows
                      students to learn by example.
                   </div>


### PR DESCRIPTION
- v5 is no longer upcoming
- send people to the getting started pages instead of githubreleases in an attempt to curtail new user confusion