### PR TITLE
update references to opcontrol et al

### DIFF
--- a/v5/releases/kernel3.2.0.rst
+++ b/v5/releases/kernel3.2.0.rst
@@ -19,6 +19,7 @@ Usability Improvements:
 - Support GCC 8.3 out of the box
 - Add a default .gitignore to new projects
 - Changes in header files will now be recompiled without having to clean
+- Replace separate :code:`initialize.cpp`, :code:`autonomous.cpp`, and :code:`opcontrol.cpp` files with a single :code:`main.cpp` file for new projects
 
 Bugfixes:
 
@@ -30,6 +31,8 @@ Bugfixes:
 
 Important upgrade notes
 -----------------------
+
+As we are replacing the three :code:`initialize.cpp`, :code:`autonomous.cpp`, and :code:`opcontrol.cpp` files with a single :code:`main.cpp` file, the :code:`main.cpp` file will be introduced into your project when you upgrade. If you compile the project right away, you will likely be faced with multiple definition errors for the competition tasks. To resolve this, you can either delete the new :code:`main.cpp`, or move the contents of your competition task functions into the new file, deleting the previous files. If your project structure has been significantly modified from the default, we trust that you will know how to resolve this issue on your own. Also note that if you have already consolidated the three files listed above into a single :code:`main.cpp` file, this will not be an issue.
 
 If your code checked :code:`errno` values set by PROS functions, you may need to change the values you compare with. Check each function's documentation for more information.
 

--- a/v5/releases/kernel3.2.0.rst
+++ b/v5/releases/kernel3.2.0.rst
@@ -4,3 +4,33 @@ PROS Kernel 3.2.0 Release
 
 .. post:: 7 September, 2019
    :tags: blog, kernel-release
+
+New Features:
+
+- Upgrade LVGL to version 5.3
+- Add an alternate :code:`pros::Task` constructor that takes only a task function, parameters, and a name.
+- Add an alternate API for generic serial communications over the smart ports
+- Add a better data abort handler that prints a stack trace
+
+Usability Improvements:
+
+- Add Makefile variable for excluding libraries from the cold image
+- Improve Makefile compile speed
+- Support GCC 8.3 out of the box
+- Add a default .gitignore to new projects
+- Changes in header files will now be recompiled without having to clean
+
+Bugfixes:
+
+- Make :code:`vision_read_by_sig` properly transform coordinates and respect array boundaries
+- Make VDML/ADI :code:`errno` values more consistent
+- Other assorted VDML/ADI bugfixes
+- Fix generic serial communications driver
+- Fix C++ file I/O
+
+Important upgrade notes
+-----------------------
+
+If your code checked :code:`errno` values set by PROS functions, you may need to change the values you compare with. Check each function's documentation for more information.
+
+We have upgraded LVGL to 5.3, but since starting the upgrade process LVGL 6.0 was released, which has changed things a lot, and the online documentation for LVGL now reflects information for version 6.0. Please see `this link <https://docs.littlevgl.com/en/html/index.html#where-can-i-find-the-documentation-of-the-previous-version-v5-3>`_ for information on where to find the documenation for LVGL 5.3.

--- a/v5/tutorials/general/project-structure.rst
+++ b/v5/tutorials/general/project-structure.rst
@@ -50,11 +50,12 @@ src
 ===
 
 **User code** has the actual sequential instructions that govern the
-robot's behavior. PROS by default splits the user code up into
+robot's behavior. Prior to PROS kernel 3.2.0, new projects by default split user code into
 autonomous (``autonomous.c`` or ``autonomous.cpp``), driver control
 (``opcontrol.c`` or ``opcontrol.cpp``), and initialization
 (``initialize.c`` or ``initialize.cpp``) files. Code in one file can talk to code in
-another file using declarations in the header files.
+another file using declarations in the header files. Beginning with PROS kernel 3.2.0, new projects by
+default have a single ``main.cpp`` file that contains all of the competition task functions.
 
 New user code files can be created in the ``src`` directory, as long as the name
 ends with ``.c`` or ``.cpp`` it will be compiled with the others.

--- a/v5/tutorials/walkthrough/clawbot.rst
+++ b/v5/tutorials/walkthrough/clawbot.rst
@@ -104,37 +104,62 @@ PROS Project Structure
 When you create your project, PROS will copy all of the files necessary
 to build your project. The structure of the project looks like:
 
-.. highlight:: none
+.. tabs ::
+   .. group-tab :: After 3.2.0
+      .. highlight:: none
+      ::
 
-::
+         project
+         │   project.pros        (used by PROS CLI to know kernel version and other metadata)
+         │   Makefile            (instructs make how to compile your project)
+         |   common.mk           (helper file for Makefile)
+         │
+         └───src                 (source files should go here)
+         │   │   main.cpp        (source for competition task functions, like operator control and autonomous)
+         |
+         └───include             (Header files should go in here)
+         │   │   api.h           (Lets source files know PROS API functions)
+         │   │   main.h          (Includes api.h and anything else you want to include project-wide)
+         |   └───pros            (Contains all of the specific header files for the PROS API functions)
+         |   └───okapi           (Contains all of the header files for OkapiLib)
+         |   └───display         (Contains all of the header files for LVGL, the graphics library for the V5 screen)
+         │
+         └───firmware
+         │   libpros.a       (Pre-compiled PROS library)
+         │   okapilib.a      (Pre-compiled OkapiLib library)
+         |   v5.ld           (Instructs the linker how to construct binaries for the V5)
 
-  project
-  │   project.pros        (used by PROS CLI to know kernel version and other metadata)
-  │   Makefile            (instructs make how to compile your project)
-  |   common.mk           (helper file for Makefile)
-  │
-  └───src                 (source files should go here)
-  │   │   autonomous.cpp  (source for autonomous function)
-  │   │   initialize.cpp  (source for initialization)
-  │   │   opcontrol.cpp   (source for operator control)
-  |
-  └───include             (Header files should go in here)
-  │   │   api.h           (Lets source files know PROS API functions)
-  │   │   main.h          (Includes api.h and anything else you want to include project-wide)
-  |   └───pros            (Contains all of the specific header files for the PROS API functions)
-  |   └───okapi           (Contains all of the header files for OkapiLib)
-  |   └───display         (Contains all of the header files for LVGL, the graphics library for the V5 screen)
-  │
-  └───firmware 
-      │   libpros.a       (Pre-compiled PROS library)
-      │   okapilib.a      (Pre-compiled OkapiLib library)
-      |   v5.ld           (Instructs the linker how to construct binaries for the V5)
+   .. group-tab :: Before 3.2.0
+      .. highlight:: none
+      ::
+
+         project
+         │   project.pros        (used by PROS CLI to know kernel version and other metadata)
+         │   Makefile            (instructs make how to compile your project)
+         |   common.mk           (helper file for Makefile)
+         │
+         └───src                 (source files should go here)
+         │   │   autonomous.cpp  (source for autonomous function)
+         │   │   initialize.cpp  (source for initialization)
+         │   │   opcontrol.cpp   (source for operator control)
+         |
+         └───include             (Header files should go in here)
+         │   │   api.h           (Lets source files know PROS API functions)
+         │   │   main.h          (Includes api.h and anything else you want to include project-wide)
+         |   └───pros            (Contains all of the specific header files for the PROS API functions)
+         |   └───okapi           (Contains all of the header files for OkapiLib)
+         |   └───display         (Contains all of the header files for LVGL, the graphics library for the V5 screen)
+         │
+         └───firmware
+         │   libpros.a       (Pre-compiled PROS library)
+         │   okapilib.a      (Pre-compiled OkapiLib library)
+         |   v5.ld           (Instructs the linker how to construct binaries for the V5)
 
 
 .. note::
-   By convention, the ``opcontrol()``, ``autonomous()``, and initialize functions are separated into separate 
-   files (opcontrol.cpp, autonomous.cpp, and initialize.cpp). They could be all in the same file, but it can be helpful to 
-   organize your functions into multiple files to keep things from becoming messy.
+   Prior to PROS kernel 3.2.0, the ``opcontrol()``, ``autonomous()``, and initialize functions are separated into separate 
+   files (opcontrol.cpp, autonomous.cpp, and initialize.cpp). After PROS kernel 3.2.0, they are by default kept in one file
+   (main.cpp). These could be separated again if you so wish.
 
 Drive Control 
 =============
@@ -190,7 +215,7 @@ and then we'll run the tank drive code.
    .. group-tab :: C++
       .. highlight:: cpp
       .. code-block:: cpp
-         :caption: opcontrol.cpp 
+         :caption: main.cpp 
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -212,7 +237,7 @@ and then we'll run the tank drive code.
    .. group-tab :: C
       .. highlight:: c
       .. code-block:: c
-         :caption: opcontrol.c
+         :caption: main.c
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -255,7 +280,7 @@ wheels.
    .. group-tab :: C++
       .. highlight:: cpp
       .. code-block:: cpp
-         :caption: opcontrol.cpp 
+         :caption: main.cpp 
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -281,7 +306,7 @@ wheels.
    .. group-tab :: C
       .. highlight:: c
       .. code-block:: c
-         :caption: opcontrol.c
+         :caption: main.c
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -354,7 +379,7 @@ is pressed on the controller, and move the lift in that direction if so.
    .. group-tab :: C++
       .. highlight:: cpp
       .. code-block:: cpp
-         :caption: opcontrol.cpp 
+         :caption: main.cpp 
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -392,7 +417,7 @@ is pressed on the controller, and move the lift in that direction if so.
    .. group-tab :: C
       .. highlight:: c
       .. code-block:: c
-         :caption: opcontrol.c
+         :caption: main.c
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -434,7 +459,7 @@ We will control the claw in the same manner as the lift, by toggling its movemen
    .. group-tab :: C++
       .. highlight:: cpp
       .. code-block:: cpp
-         :caption: opcontrol.cpp 
+         :caption: main.cpp 
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -484,7 +509,7 @@ We will control the claw in the same manner as the lift, by toggling its movemen
    .. group-tab :: C
       .. highlight:: c
       .. code-block:: c
-         :caption: opcontrol.c
+         :caption: main.c
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -558,7 +583,7 @@ And here is the updated code:
    .. group-tab :: C++
       .. highlight:: cpp
       .. code-block:: cpp
-         :caption: opcontrol.cpp 
+         :caption: main.cpp 
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -625,7 +650,7 @@ And here is the updated code:
    .. group-tab :: C
       .. highlight:: c
       .. code-block:: c
-         :caption: opcontrol.c
+         :caption: main.c
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -693,7 +718,7 @@ we will prevent the lift from being driven down further.
    .. group-tab :: C++
       .. highlight:: cpp
       .. code-block:: cpp
-         :caption: opcontrol.cpp 
+         :caption: main.cpp 
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -762,7 +787,7 @@ we will prevent the lift from being driven down further.
    .. group-tab :: C
       .. highlight:: c
       .. code-block:: c
-         :caption: opcontrol.c
+         :caption: main.c
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -834,7 +859,7 @@ The autonomous program runs without the use of a controller. We will make a simp
    .. group-tab :: C++
       .. highlight:: cpp
       .. code-block:: cpp
-         :caption: autonomous.cpp 
+         :caption: main.cpp 
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -852,7 +877,7 @@ The autonomous program runs without the use of a controller. We will make a simp
    .. group-tab :: C
       .. highlight:: c
       .. code-block:: c
-         :caption: autonomous.c
+         :caption: main.c
          :linenos:
 
          #define LEFT_WHEELS_PORT 1

--- a/v5/tutorials/walkthrough/creating-c-project.rst
+++ b/v5/tutorials/walkthrough/creating-c-project.rst
@@ -3,8 +3,8 @@ Creating a C Project
 ====================
 
 By default, a new PROS project contains C++ source files and the C++ API. If you would prefer to program in C
-instead, change the extension of the source files (``initialize.cpp``, ``autonomous.cpp``, and ``opcontrol.cpp``)
-to ``.c``. 
+instead, change the extension of the source files (prior to PROS kernel 3.2.0: ``initialize.cpp``, ``autonomous.cpp``,
+and ``opcontrol.cpp``; after PROS kernel 3.2.0: ``main.cpp``) to ``.c``. 
 
 .. warning:: Do not change any of the PROS header files in this process. That will cause the wrong files to be
              included in your project, and will likely prevent compilation. Only modify the extensions of the ``.cpp`` files.


### PR DESCRIPTION
I somehow forgot to mention that new projects will by default now have a src/main.cpp instead of the three files we had previously. This PR goes through and changes that for all the tutorials and stuff as well.