### PR TITLE
Fix compilation issue with Ablog

### DIFF
--- a/v5/conf.py
+++ b/v5/conf.py
@@ -131,5 +131,5 @@ html_show_sphinx = False
 highlight_language = "c"
 nitpicky = True
 
-
+blog_baseurl = 'pros.cs.purdue.edu'
 blog_path = 'blog/index'


### PR DESCRIPTION
Not sure why I was experiencing this issue and not Azure or other devs, but it looks like the `blog_baseurl` value is required for proper compilation with ablog. Further discussion can be found in sunpy/ablog#43.