### PR TITLE
Link to Slack Workspace Has Expired On Pros Website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 .vscode
 myenv/
 pros-docs.tar.gz
+venv/

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,4 @@
 	path = sphinx-tabs
 	url = https://github.com/purduesigbots/sphinx-tabs.git
 	branch = master
+	ignore = dirty

--- a/home/_templates/index.html
+++ b/home/_templates/index.html
@@ -49,7 +49,7 @@
          <div class="container main">
             <div class="fullbg_bigtxt"><img src="_static/img/pros-tux.png" alt="PROS"></div>
             <div class="fullbg_smalltxt">
-               Open Source C/C++ Development for VEX Cortex and the Upcoming v5 Microcontroller<br/>
+               Open Source C/C++ Development for VEX V5 and VEX Cortex<br/>
                <div class ="fullbg_btn pros-bounce">
                   <a href="#about"><span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span></a>
                </div>
@@ -94,20 +94,15 @@
          <div class="big_title">
             <div class="big_title_txt montserrat_font">GET STARTED <span class="text_color">NOW</span></div>
             <div class="text_und_big_title">
-               After installing PROS, read <a href="cortex/getting-started/index.html">Getting Started</a> for an introduction to PROS. <br/>
-               Then, refer to the <a href="cortex/tutorials/index.html">tutorials</a> or <a href="cortex/api/index.html">API documentation</a>.
+               After installing PROS, check out the <a href="v5/tutorials/index.html">tutorials</a> for an introduction to the ecosystem and the <a href="v5/api/index.html">API documentation</a> for more detailed information.
             </div>
             <div class="big_title_txt_separ background_color"></div>
          </div>
          <div class="section_content">
             <div class="buy_content text-center">
-                <a id="pros3-dl-link" href="https://github.com/purduesigbots/pros-cli3/releases" class="buy_btn">DOWNLOAD PROS FOR V5</a>
+                <a id="pros3-dl-link" href="v5/getting-started/" class="buy_btn">GETTING STARTED</a>
              </div>
           </div>
-          <div class="section_content">
-            <div class="buy_content text-center">
-               <a id="pros2-dl-link" href="https://github.com/purduesigbots/pros/releases/tag/2.12.2" class="buy_btn">DOWNLOAD PROS FOR CORTEX</a>
-            </div>
          </div>
       </section>
       <!-- Features
@@ -127,7 +122,7 @@
                      OPEN SOURCE
                   </div>
                   <div class="service_p">
-                     All PROS development is open sourced and available for the community to inspect.
+                     All PROS development is open source and available for the community to inspect.
                      We believe that sharing source improves PROS through community contributions and allows
                      students to learn by example.
                   </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sphinx_tabs==1.1.10
 ablog==0.9.4
 sphinx-click==2.0.1
 pros-cli-v5
+click

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Sphinx
-sphinx_tabs
-ablog
-sphinx-click
+Sphinx==1.8.5
+sphinx_tabs==1.1.10
+ablog==0.9.4
+sphinx-click==2.0.1
 pros-cli-v5

--- a/v5/api/c/adi.rst
+++ b/v5/api/c/adi.rst
@@ -35,7 +35,8 @@ Do not use this function when the sensor value might be unstable
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The port number is out of range or the port is not configured to be an analog input.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
+- ``EADDRINUSE``  - The port is not configured as an analog input
 
 Analogous to `pros::ADIAnalogIn::calibrate <../cpp/adi.html#calibrate>`_.
 
@@ -78,8 +79,8 @@ The meaning of the returned value varies depending on the sensor attached.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The port number is out of range or the port is not configured to be an analog input.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
+- ``EADDRINUSE``  - The port is not configured as an analog input
 
 Analogous to `pros::ADIAnalogIn::get_value <../cpp/adi.html#get-value>`_.
 
@@ -125,8 +126,8 @@ causing drift over time. Use `adi_analog_read_calibrated_HR`_ instead.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The port number is out of range or the port is not configured to be an analog input.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
+- ``EADDRINUSE``  - The port is not configured as an analog input
 
 Analogous to `pros::ADIAnalogIn::get_value_calibrated <../cpp/adi.html#get-value-calibrated>`_.
 
@@ -175,8 +176,8 @@ in the wash when integrated over time. Think of the value as the true value time
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The port number is out of range or the port is not configured to be an analog input.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
+- ``EADDRINUSE``  - The port is not configured as an analog input
 
 Analogous to `pros::ADIAnalogIn::get_value_calibrated_HR <../cpp/adi.html#get-value-calibrated-HR>`_.
 
@@ -226,8 +227,8 @@ presses, and not in any other tasks.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The port number is out of range or the port is not configured to be a digital input.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
+- ``EADDRINUSE``  - The port is not configured as a digital input
 
 Analogous to `pros::ADIDigitalIn::get_new_press <../cpp/adi.html#get-new-press>`_.
 
@@ -275,8 +276,8 @@ return value is undefined for pins configured as Analog inputs.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The port number is out of range or the port is not configured to be a digital input.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
+- ``EADDRINUSE``  - The port is not configured as a digital input
 
 Analogous to `pros::ADIDigitalIn::get_value <../cpp/adi.html#id5>`_.
 
@@ -317,8 +318,8 @@ Sets the digital value (1 or 0) of a pin configured as a digital output.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The port number is out of range or the port is not configured to be a digital output.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
+- ``EADDRINUSE``  - The port is not configured as a digital output
 
 Analogous to `pros::ADIDigitalOut::set_value <../cpp/adi.html#id8>`_.
 
@@ -366,8 +367,8 @@ There are 360 ticks in one revolution.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The encoder port number is out of range or the port is not configured to be an encoder.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
+- ``EADDRINUSE``  - The port is not configured as an encoder
 
 Analogous to `pros::ADIEncoder::get_value <../cpp/adi.html#id11>`_.
 
@@ -410,8 +411,8 @@ Initializes and enables a quadrature encoder on two ADI ports.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given ports do not match the criteria in the parameter list below.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
+- ``EADDRINUSE``  - The port is not configured as an encoder
 
 Analogous to `pros::ADIEncoder::ADIEncoder <../cpp/adi.html#id9>`_.
 
@@ -461,8 +462,8 @@ method before stopping or starting an encoder.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The encoder port number is out of range or the port is not configured to be an encoder.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
+- ``EADDRINUSE``  - The port is not configured as an encoder
 
 Analogous to `pros::ADIEncoder::reset <../cpp/adi.html#reset>`_.
 
@@ -503,8 +504,8 @@ Stops and disables the encoder.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The encoder port number is out of range or the port is not configured to be an encoder.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
+- ``EADDRINUSE``  - The port is not configured as an encoder
 
 .. tabs ::
    .. tab :: Prototype
@@ -543,8 +544,8 @@ Returns the last set speed of the motor on the given port.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The port number is out of range or the port is not configured as a motor.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
+- ``EADDRINUSE``  - The port is not configured as a motor
 
 Analogous to `pros::ADIMotor::get_value <../cpp/adi.html#id14>`_.
 
@@ -585,8 +586,8 @@ Sets the speed of the motor on the given port.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The port number is out of range or the port is not configured as a motor.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
+- ``EADDRINUSE``  - The port is not configured as a motor
 
 Analogous to `pros::ADIMotor::set_value <../cpp/adi.html#id15>`_.
 
@@ -628,8 +629,8 @@ Stops the motor on the given port.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The port number is out of range or the port is not configured as a motor.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
+- ``EADDRINUSE``  - The port is not configured as a motor
 
 Analogous to `pros::ADIMotor::stop <../cpp/adi.html#id16>`_.
 
@@ -670,8 +671,7 @@ Configures the pin as an input or output with a variety of settings.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The port number is out of range.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
 
 .. tabs ::
    .. tab :: Prototype
@@ -709,8 +709,7 @@ Returns the configuration for the given ADI port.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The port number is out of range.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
 
 Analogous to `pros::ADIPort::get_config <../cpp/adi.html#get-config>`_.
 
@@ -750,8 +749,7 @@ Returns the value for the given ADI port.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The port number is out of range.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
 
 Analogous to `pros::ADIPort::get_value <../cpp/adi.html#id18>`_.
 
@@ -790,8 +788,7 @@ Configures an ADI port to act as a given sensor type.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The port number is out of range.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
 
 Analogous to `pros::ADIPort::set_config <../cpp/adi.html#set-config>`_.
 
@@ -834,8 +831,7 @@ depending on the configuration of the port.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The port number is out of range.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
 
 Analogous to `pros::ADIPort::set_value <../cpp/adi.html#id20>`_.
 
@@ -880,8 +876,8 @@ returned.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The ultrasonic port number is out of range or the ultrasonic port is not properly configured.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
+- ``EADDRINUSE``  - The port is not configured as an ultrasonic
 
 Analogous to `pros::ADIUltrasonic::get_value <../cpp/adi.html#id24>`_.
 
@@ -925,8 +921,8 @@ Initializes an ultrasonic sensor on the specified ADI ports.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given ports do not match the parameter criteria given below.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
+- ``EADDRINUSE``  - The port is not configured as an ultrasonic
 
 Analogous to `pros::ADIUltrasonic::ADIUltrasonic <../cpp/adi.html#id22>`_.
 
@@ -972,8 +968,8 @@ Stops and disables the ultrasonic sensor.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The ultrasonic port number is out of range or the ultrasonic port is not properly configured.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
+- ``EADDRINUSE``  - The port is not configured as an ultrasonic
 
 .. tabs ::
    .. tab :: Prototype
@@ -1021,8 +1017,8 @@ called from initialize when the robot is stationary.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given ports do not match the parameter criteria given below.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
+- ``EADDRINUSE``  - The port is not configured as a gyro
 
 Analogous to `pros::ADIGyro::ADIGyro <../cpp/adi.html#>`_.
 
@@ -1073,8 +1069,8 @@ whole rotation.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given ports do not match the parameter criteria given below.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
+- ``EADDRINUSE``  - The port is not configured as a gyro
 
 Analogous to `pros::ADIGyro::get_value <../cpp/adi.html#>`_.
 
@@ -1118,8 +1114,8 @@ Resets the gyro value to zero.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given ports do not match the parameter criteria given below.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
+- ``EADDRINUSE``  - The port is not configured as a gyro
 
 Analogous to `pros::ADIGyro::reset <../cpp/adi.html#>`_.
 
@@ -1171,8 +1167,8 @@ Disables the gyro and voids the configuration on its port.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given ports do not match the parameter criteria given below.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
+- ``EADDRINUSE``  - The port is not configured as a gyro
 
 .. tabs ::
    .. tab :: Prototype

--- a/v5/api/c/motors.rst
+++ b/v5/api/c/motors.rst
@@ -25,8 +25,8 @@ from the PROS 2 API.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::move <../cpp/motors.html#move>`_.
 
@@ -75,8 +75,8 @@ the position when it was most recently reset with `motor_tare_position`_.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::move_absolute <../cpp/motors.html#move-absolute>`_.
 
@@ -116,7 +116,7 @@ Analogous to `pros::Motor::move_absolute <../cpp/motors.html#move-absolute>`_.
 ============ ===============================================================
  port         The V5 port number from 1-21
  position     The absolute position to move to in the motor's encoder units
- velocity     The maximum allowable velocity for the movement
+ velocity     The maximum allowable velocity for the movement in RPM
 ============ ===============================================================
 
 **Returns:** ``1`` if the operation was successful or ``PROS_ERR`` if the operation failed,
@@ -130,7 +130,8 @@ motor_move_relative
 Sets the relative target position for the motor to move to.
 
 This movement is relative to the current position of the motor as given in
-`motor_get_position`_.
+`motor_get_position`_. Providing 10.0 as the position parameter would result
+in the motor moving clockwise 10 units, no matter what the current position is.
 
 .. note:: This function simply sets the target for the motor, it does not block program
           execution until the movement finishes. The example code shows how to block
@@ -138,8 +139,8 @@ This movement is relative to the current position of the motor as given in
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::move_relative <../cpp/motors.html#move-relative>`_.
 
@@ -197,8 +198,8 @@ voltage.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::move_velocity <../cpp/motors.html#move-velocity>`_.
 
@@ -240,8 +241,8 @@ Sets the voltage for the motor from -12000 mV to 12000 mV.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::move_voltage <../cpp/motors.html#move-voltage>`_.
 
@@ -284,8 +285,8 @@ a profiled movement.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::modify_profiled_velocity <../cpp/motors.html#modify-profiled-velocity>`_.
 
@@ -326,8 +327,8 @@ Gets the target position set for the motor by the user.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::get_target_position <../cpp/motors.html#get-target-position>`_.
 
@@ -366,8 +367,8 @@ Gets the velocity commanded to the motor by the user.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::get_target_velocity <../cpp/motors.html#get-target-velocity>`_.
 
@@ -411,8 +412,8 @@ Gets the actual velocity of the motor.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::get_actual_velocity <../cpp/motors.html#get-actual-velocity>`_.
 
@@ -453,8 +454,8 @@ Gets the current drawn by the motor in mA.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::get_current_draw <../cpp/motors.html#get-current-draw>`_.
 
@@ -495,8 +496,8 @@ Gets the direction of movement for the motor.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::get_direction <../cpp/motors.html#get-direction>`_.
 
@@ -542,8 +543,8 @@ is drawing power but not moving.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::get_efficiency <../cpp/motors.html#get-efficiency>`_.
 
@@ -586,8 +587,8 @@ Compare this bitfield to the bitmasks in `motor_fault_e_t`_.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::get_faults <../cpp/motors.html#get-faults>`_.
 
@@ -629,8 +630,8 @@ Compare this bitfield to the bitmasks in `motor_flag_e_t`_.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::get_flags <../cpp/motors.html#get-flags>`_.
 
@@ -670,8 +671,8 @@ Gets the absolute position of the motor in its encoder units.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::get_position <../cpp/motors.html#get-position>`_.
 
@@ -712,8 +713,8 @@ Gets the power drawn by the motor in Watts.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::get_power <../cpp/motors.html#get-power>`_.
 
@@ -755,8 +756,8 @@ Gets the raw encoder count of the motor at a given timestamp.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::get_raw_position <../cpp/motors.html#get-raw-position>`_.
 
@@ -803,8 +804,8 @@ temperature reading is greater than or equal to 55 C.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::get_temperature <../cpp/motors.html#get-temperature>`_.
 
@@ -845,8 +846,8 @@ Gets the torque generated by the motor in Nm.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::get_torque <../cpp/motors.html#get-torque>`_.
 
@@ -887,8 +888,8 @@ Gets the voltage delivered to the motor in mV.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::get_voltage <../cpp/motors.html#get-voltage>`_.
 
@@ -929,8 +930,8 @@ Gets the zero position flag for the motor.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::get_zero_position_flag <../cpp/motors.html#get-zero-position-flag>`_.
 
@@ -972,8 +973,8 @@ Gets the zero velocity flag for the motor.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::is_stopped <../cpp/motors.html#is-stopped>`_.
 
@@ -1014,8 +1015,8 @@ Detects if the motor is drawing over its current limit.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::is_over_current <../cpp/motors.html#is-over-current>`_.
 
@@ -1057,8 +1058,8 @@ Gets the temperature limit flag for the motor.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::is_over_temp <../cpp/motors.html#is-over-temp>`_.
 
@@ -1212,8 +1213,8 @@ Gets the brake mode of the motor.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::get_brake_mode <../cpp/motors.html#get-brake-mode>`_.
 
@@ -1251,8 +1252,8 @@ Gets the current limit for the motor in mA. The default limit is 2500 mA.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::get_current_limit <../cpp/motors.html#get-current-limit>`_.
 
@@ -1290,8 +1291,8 @@ Gets the `encoder units <motors.html#motor-encoder-units-e-t>`_ set for the moto
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::get_encoder_units <../cpp/motors.html#get-encoder-units>`_.
 
@@ -1329,8 +1330,8 @@ Gets the `gearset <motors.html#motor-gearset-e-t>`_` that was set for the motor.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::get_gearing <../cpp/motors.html#get-gearing>`_.
 
@@ -1370,8 +1371,8 @@ motor_set_pos_pid_full functions have not been used.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Additionally, in an error state all values of the returned struct are set
 to their negative maximum values.
@@ -1426,8 +1427,8 @@ motor_set_vel_pid_full functions have not been used.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Additionally, in an error state all values of the returned struct are set
 to their negative maximum values.
@@ -1480,8 +1481,8 @@ Gets the voltage limit set by the user.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::get_voltage_limit <../cpp/motors.html#get-voltage-limit>`_.
 
@@ -1519,8 +1520,8 @@ Gets the operation direction of the motor as set by the user.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::is_reversed <../cpp/motors.html#is-reversed>`_.
 
@@ -1558,8 +1559,8 @@ Sets one of `motor_brake_mode_e_t`_ to the motor.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::set_brake_mode <../cpp/motors.html#set-brake-mode>`_.
 
@@ -1601,8 +1602,8 @@ The default limit is 2500 mA.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::set_current_limit <../cpp/motors.html#set-current-limit>`_.
 
@@ -1646,8 +1647,8 @@ Sets one of `motor_encoder_units_e_t`_ for the motor encoder.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::set_encoder_units <../cpp/motors.html#set-encoder-units>`_.
 
@@ -1687,8 +1688,8 @@ Sets one of `motor_gearset_e_t`_ for the motor.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::set_gearing <../cpp/motors.html#set-gearing>`_.
 
@@ -1734,8 +1735,8 @@ Only non-zero values of the struct will change the existing motor constants.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::set_pos_pid <../cpp/motors.html#set-pos-pid>`_.
 
@@ -1785,8 +1786,8 @@ Only non-zero values of the struct will change the existing motor constants.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::set_pos_pid_full <../cpp/motors.html#set-pos-pid-full>`_.
 
@@ -1838,8 +1839,8 @@ This will invert its movements and the values returned for its position.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::set_reversed <../cpp/motors.html#set-reversed>`_.
 
@@ -1885,8 +1886,8 @@ Only non-zero values of the struct will change the existing motor constants.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::set_vel_pid <../cpp/motors.html#set-vel-pid>`_.
 
@@ -1936,8 +1937,8 @@ Only non-zero values of the struct will change the existing motor constants.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::set_vel_pid_full <../cpp/motors.html#set-vel-pid-full>`_.
 
@@ -1987,8 +1988,8 @@ Sets the voltage limit for the motor in mV.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::set_voltage_limit <../cpp/motors.html#set-voltage-limit>`_.
 
@@ -2034,8 +2035,8 @@ This will be the future reference point for the motor's "absolute" position.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::set_zero_position <../cpp/motors.html#set-zero-position>`_.
 
@@ -2088,8 +2089,8 @@ Sets the "absolute" zero position of the motor to its current position.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `pros::Motor::tare_position <../cpp/motors.html#tare-position>`_.
 

--- a/v5/api/c/vision.rst
+++ b/v5/api/c/vision.rst
@@ -19,8 +19,8 @@ displaying the most prominent object signature color.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The device cannot be configured as a vision sensor
 
 .. tabs ::
    .. tab :: Prototype
@@ -122,8 +122,8 @@ for the additional function parameters.
 This function uses the following values of errno when an error state is
 reached:
 
-	- ``EINVAL`` - Fewer than two signatures have been provided, or one of the
-             		 signatures is out of its [1-7] range.
+	- ``EINVAL`` - Fewer than two signatures have been provided or one of the
+             		 signatures is out of its [1-7] range (or 0 when omitted)
 
 .. tabs ::
    .. tab :: Prototype
@@ -172,10 +172,11 @@ Gets the nth largest object of the given signature according to size_id.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The device cannot be configured as a vision sensor (e.g. it has been reconfigured)
+- ``EINVAL``  - sig_id is outside the range [1-7]
 - ``EDOM`` - size_id is greater than the number of available objects.
-- ``EHOSTDOWN`` - Reading the vision sensor failed for an unknown reason.
+- ``EAGAIN`` - Reading the vision sensor failed for an unknown reason.
 
 .. tabs ::
    .. tab :: Prototype
@@ -225,8 +226,8 @@ Gets the nth largest object according to size_id.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The device cannot be configured as a vision sensor (e.g. it has been reconfigured)
 - ``EDOM`` - size_id is greater than the number of available objects.
 - ``EHOSTDOWN`` - Reading the vision sensor failed for an unknown reason.
 
@@ -274,10 +275,9 @@ Gets the nth largest object of the given color code according to size_id.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
-- ``EDOM`` - size_id is greater than the number of available objects.
-- ``EHOSTDOWN`` - Reading the vision sensor failed for an unknown reason.
+- ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The device cannot be configured as a vision sensor (e.g. it has been reconfigured)
+- ``EAGAIN`` - Reading the vision sensor failed for an unknown reason.
 
 .. tabs ::
    .. tab :: Prototype
@@ -328,8 +328,8 @@ Gets the exposure parameter of the Vision Sensor.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The device cannot be configured as a vision sensor (e.g. it has been reconfigured)
 
 .. tabs ::
    .. tab :: Prototype
@@ -368,8 +368,8 @@ Returns the number of objects currently detected by the Vision Sensor.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The device cannot be configured as a vision sensor (e.g. it has been reconfigured)
 
 .. tabs ::
    .. tab :: Prototype
@@ -410,8 +410,6 @@ Gets the object detection signature with the given id number.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
 
 .. tabs ::
    .. tab :: Prototype
@@ -452,8 +450,8 @@ Gets the white balance parameter of the Vision Sensor.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The device cannot be configured as a vision sensor (e.g. it has been reconfigured)
 
 .. tabs ::
    .. tab :: Prototype
@@ -526,8 +524,9 @@ Reads up to object_count object descriptors into object_arr.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The device cannot be configured as a vision sensor (e.g. it has been reconfigured)
+- ``EINVAL``  - sig_id is outside the range [1-7]
 - ``EDOM`` - size_id is greater than the number of available objects.
 
 .. tabs ::
@@ -587,8 +586,8 @@ Reads up to object_count object descriptors into object_arr.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The device cannot be configured as a vision sensor (e.g. it has been reconfigured)
 - ``EDOM`` - size_id is greater than the number of available objects.
 
 .. tabs ::
@@ -645,9 +644,8 @@ Reads up to object_count object descriptors into object_arr.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
-- ``EDOM`` - size_id is greater than the number of available objects.
+- ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The device cannot be configured as a vision sensor (e.g. it has been reconfigured)
 
 .. tabs ::
    .. tab :: Prototype
@@ -709,8 +707,10 @@ Set the white balance parameter manually on the Vision Sensor.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The device cannot be configured as a vision sensor (e.g. it has been reconfigured)
+- ``EINVAL``  - Enable was not 0 or 1
+
 
 .. tabs ::
    .. tab :: Prototype
@@ -749,8 +749,8 @@ Sets the exposure parameter of the Vision Sensor.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The device cannot be configured as a vision sensor (e.g. it has been reconfigured)
 
 .. tabs ::
    .. tab :: Prototype
@@ -791,8 +791,8 @@ Sets the vision sensor LED color, overriding the automatic behavior.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The device cannot be configured as a vision sensor (e.g. it has been reconfigured)
 
 .. tabs ::
    .. tab :: Prototype
@@ -834,8 +834,6 @@ Stores the supplied object detection signature onto the vision sensor.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
 
 .. tabs ::
    .. tab :: Prototype
@@ -881,8 +879,8 @@ This function will disable auto white-balancing.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The device cannot be configured as a vision sensor (e.g. it has been reconfigured)
 
 .. tabs ::
    .. tab :: Prototype
@@ -926,8 +924,8 @@ function only be used to configure the sensor at the beginning of its use.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The device cannot be configured as a vision sensor (e.g. it has been reconfigured)
 
 .. tabs ::
    .. tab :: Prototype
@@ -968,8 +966,8 @@ Sets the Wi-Fi mode of the Vision Sensor
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
+- ``EACCESS``  - Another resources is currently trying to access the port
 
 .. tabs ::
    .. tab :: Prototype

--- a/v5/api/cpp/adi.rst
+++ b/v5/api/cpp/adi.rst
@@ -22,8 +22,7 @@ Constructor(s)
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given ports do not match the parameter criteria given below.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
 
 .. tabs ::
    .. tab :: Prototype
@@ -78,7 +77,7 @@ Do not use this function when the sensor value might be unstable
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``EADDRINUSE``  - The port is not configured as an analog input  (e.g. the port has been reconfigured)
 
 Analogous to `adi_analog_calibrate <../c/adi.html#adi-analog-calibrate>`_.
 
@@ -118,7 +117,7 @@ Inherited from `ADIPort::get_value <get_value_>`_.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``EADDRINUSE``  - The port is not configured as an analog input  (e.g. the port has been reconfigured)
 
 Analogous to `adi_analog_read <../c/adi.html#adi-analog-read>`_.
 
@@ -156,7 +155,7 @@ causing drift over time. Use `adi_analog_read_calibrated_HR`_ instead.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``EADDRINUSE``  - The port is not configured as an analog input  (e.g. the port has been reconfigured)
 
 Analogous to `adi_analog_read_calibrated <../c/adi.html#adi_analog_read_calibrated>`_.
 
@@ -199,7 +198,7 @@ in the wash when integrated over time. Think of the value as the true value time
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``EADDRINUSE``  - The port is not configured as an analog input  (e.g. the port has been reconfigured)
 
 Analogous to `adi_analog_read_calibrated_HR <../c/adi.html#adi_analog_read_calibrated_HR>`_.
 
@@ -235,8 +234,7 @@ Constructor(s)
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given ports do not match the parameter criteria given below.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
 
 .. tabs ::
    .. tab :: Prototype
@@ -314,8 +312,7 @@ Constructor(s)
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given ports do not match the parameter criteria given below.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
 
 .. tabs ::
    .. tab :: Prototype
@@ -361,7 +358,7 @@ presses, and not in any other tasks.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``EADDRINUSE``  - The port is not configured as a digital input  (e.g. the port has been reconfigured)
 
 Analogous to `adi_digital_get_new_press <../c/adi.html#adi-digital-get-new-press>`_.
 
@@ -402,7 +399,7 @@ Inherited from `ADIPort::get_value <get_value_>`_.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``EADDRINUSE``  - The port is not configured as a digital input  (e.g. the port has been reconfigured)
 
 Analogous to `adi_digital_read <../c/adi.html#adi-digital-read>`_.
 
@@ -439,8 +436,7 @@ Constructor(s)
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given ports do not match the parameter criteria given below.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
 
 .. tabs ::
    .. tab :: Prototype
@@ -487,7 +483,7 @@ Inherited from `ADIPort::set_value <set_value_>`_.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``EADDRINUSE``  - The port is not configured as a digital output  (e.g. the port has been reconfigured)
 
 Analogous to `adi_digital_write <../c/adi.html#adi-digital-write>`_.
 
@@ -533,8 +529,7 @@ Constructor(s)
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given ports do not match the parameter criteria given below.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
 
 .. tabs ::
    .. tab :: Prototype
@@ -579,7 +574,7 @@ There are 360 ticks in one revolution.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``EADDRINUSE``  - The port is not configured as an encoder (e.g. the port has been reconfigured)
 
 Analogous to `adi_encoder_get <../c/adi.html#adi-encoder-get>`_.
 
@@ -617,7 +612,7 @@ method before stopping or starting an encoder.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``EADDRINUSE``  - The port is not configured as an encoder (e.g. the port has been reconfigured)
 
 Analogous to `adi_encoder_reset <../c/adi.html#adi-encoder-reset>`_.
 
@@ -653,8 +648,7 @@ Constructor(s)
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given ports do not match the parameter criteria given below.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
 
 .. tabs ::
    .. tab :: Prototype
@@ -697,7 +691,7 @@ Inherited from `ADIPort::get_value <get_value_>`_.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``EADDRINUSE``  - The port is not configured as a motor (e.g. the port has been reconfigured)
 
 Analogous to `adi_motor_get <../c/adi.html#adi-motor-get>`_.
 
@@ -735,7 +729,7 @@ Inherited from `ADIPort::set_value <set_value_>`_.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``EADDRINUSE``  - The port is not configured as a motor (e.g. the port has been reconfigured)
 
 Analogous to `adi_motor_set <../c/adi.html#adi-motor-set>`_.
 
@@ -777,7 +771,7 @@ Stops the given motor.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``EADDRINUSE``  - The port is not configured as a motor (e.g. the port has been reconfigured)
 
 Analogous to `adi_motor_stop <../c/adi.html#adi-motor-stop>`_.
 
@@ -814,8 +808,7 @@ Constructor(s)
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given ports do not match the parameter criteria given below.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
 
 .. tabs ::
    .. tab :: Prototype
@@ -856,7 +849,7 @@ Returns the configuration for the given ADI port.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``EADDRINUSE``  - The port is not configured as a the type specified in the constructor (e.g. the port has been reconfigured)
 
 Analogous to `adi_port_get_config <../c/adi.html#adi-port-config-get>`_.
 
@@ -891,7 +884,7 @@ Returns the value for the given ADI port.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``EADDRINUSE``  - The port is not configured as a the type specified in the constructor (e.g. the port has been reconfigured)
 
 Analogous to `adi_port_get_value <../c/adi.html#adi-port-value-get>`_.
 
@@ -924,7 +917,7 @@ Configures an ADI port to act as a given sensor type.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``EADDRINUSE``  - The port is not configured as a the type specified in the constructor (e.g. the port has been reconfigured)
 
 Analogous to `adi_port_set_config <../c/adi.html#adi-port-config-set>`_.
 
@@ -970,7 +963,7 @@ depending on the configuration of the port.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``EADDRINUSE``  - The port is not configured as a the type specified in the constructor (e.g. the port has been reconfigured)
 
 Analogous to `adi_port_set_value <../c/adi.html#adi-port-value-set>`_.
 
@@ -1010,8 +1003,7 @@ Constructor(s)
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given ports do not match the parameter criteria given below.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
 
 .. tabs ::
    .. tab :: Prototype
@@ -1062,7 +1054,7 @@ Inherited from `ADIPort::get_value <get_value_>`_.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``EADDRINUSE``  - The port is not configured as an ultrasonic (e.g. the port has been reconfigured)
 
 Analogous to `adi_ultrasonic_get <../c/adi.html#adi-ultrasonic-get>`_.
 
@@ -1108,8 +1100,7 @@ called from initialize when the robot is stationary.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given ports do not match the parameter criteria given below.
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``ENXIO`` - The given port is not within the range of ADI Ports
 
 Analogous to `adi_gyro_init <../c/adi.html#adi-gyro-init>`_.
 
@@ -1158,7 +1149,7 @@ whole rotation.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``EADDRINUSE``  - The port is not configured as a gyro (e.g. the port has been reconfigured)
 
 Analogous to `adi_gyro_get <../c/adi.html#adi-gyro-get>`_.
 
@@ -1195,7 +1186,7 @@ Resets the gyro value to zero.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the ADI.
+- ``EADDRINUSE``  - The port is not configured as a gyro (e.g. the port has been reconfigured)
 
 Analogous to `adi_gyro_reset <../c/adi.html#adi-gyro-reset>`_.
 

--- a/v5/api/cpp/motors.rst
+++ b/v5/api/cpp/motors.rst
@@ -18,8 +18,8 @@ Constructor(s)
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EINVAL``  - The given value is not within the range of V5 ports (1-21).
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a motor
 
 .. tabs ::
    .. tab :: Prototype
@@ -187,7 +187,7 @@ from the PROS 2 API.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 .. tabs ::
    .. tab :: Prototype
@@ -255,7 +255,7 @@ from the PROS 2 API.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_move <../c/motors.html#motor-move>`_.
 
@@ -304,7 +304,7 @@ the position when it was most recently reset with `tare_position`_.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_move_absolute <../c/motors.html#motor-move-absolute>`_.
 
@@ -365,7 +365,7 @@ This movement is relative to the current position of the motor as given in
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_move_relative <../c/motors.html#motor-move-relative>`_.
 
@@ -421,7 +421,7 @@ voltage.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_move_velocity <../c/motors.html#motor-move-velocity>`_.
 
@@ -463,7 +463,7 @@ Sets the voltage for the motor from -12000 mV to 12000 mV.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_move_voltage <../c/motors.html#motor-move-voltage>`_.
 
@@ -504,7 +504,7 @@ a profiled movement.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_modify_profiled_velocity <../c/motors.html#motor-modify-profiled-velocity>`_.
 
@@ -544,7 +544,7 @@ Gets the target position set for the motor by the user.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_get_target_position <../c/motors.html#motor-get-target-position>`_.
 
@@ -578,7 +578,7 @@ Gets the velocity commanded to the motor by the user.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_get_target_velocity <../c/motors.html#motor-get-target-velocity>`_.
 
@@ -619,7 +619,7 @@ Gets the actual velocity of the motor.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_get_actual_velocity <../c/motors.html#motor-get-actual-velocity>`_.
 
@@ -655,7 +655,7 @@ Gets the current drawn by the motor in mA.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_get_current_draw <../c/motors.html#motor-get-current-draw>`_.
 
@@ -692,7 +692,7 @@ Gets the direction of movement for the motor.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_get_direction <../c/motors.html#motor-get-direction>`_.
 
@@ -734,7 +734,7 @@ is drawing power but not moving.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_get_efficiency <../c/motors.html#motor-get-efficiency>`_.
 
@@ -773,7 +773,7 @@ Compare this bitfield to the bitmasks in ``pros::motor_fault_e_t``.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_get_faults <../c/motors.html#motor-get-faults>`_.
 
@@ -811,7 +811,7 @@ Compare this bitfield to the bitmasks in ``pros::motor_flag_e_t``.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_get_flags <../c/motors.html#motor-get-flags>`_.
 
@@ -847,7 +847,7 @@ Gets the absolute position of the motor in its encoder units.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_get_position <../c/motors.html#motor-get-position>`_.
 
@@ -884,7 +884,7 @@ Gets the power drawn by the motor in Watts.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_get_power <../c/motors.html#motor-get-power>`_.
 
@@ -921,7 +921,7 @@ Gets the raw encoder count of the motor at a given timestamp.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_get_raw_position <../c/motors.html#motor-get-raw-position>`_.
 
@@ -968,7 +968,7 @@ temperature reading is greater than or equal to 55 C.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_get_temperature <../c/motors.html#motor-get-temperature>`_.
 
@@ -1005,7 +1005,7 @@ Gets the torque generated by the motor in Nm.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_get_torque <../c/motors.html#motor-get-torque>`_.
 
@@ -1042,7 +1042,7 @@ Gets the voltage delivered to the motor in mV.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_get_voltage <../c/motors.html#motor-get-voltage>`_.
 
@@ -1079,7 +1079,7 @@ Gets the zero position flag for the motor.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_get_zero_position_flag <../c/motors.html#motor-get-zero-position-flag>`_.
 
@@ -1117,7 +1117,7 @@ Gets the zero velocity flag for the motor.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_is_stopped <../c/motors.html#motor-is-stopped>`_.
 
@@ -1154,7 +1154,7 @@ Detects if the motor is drawing over its current limit.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_is_over_current <../c/motors.html#motor-is-over-current>`_.
 
@@ -1192,7 +1192,7 @@ Gets the temperature limit flag for the motor.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_is_over_temp <../c/motors.html#motor-is-over-temp>`_.
 
@@ -1354,7 +1354,7 @@ Gets the brake mode of the motor.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_get_brake_mode <../c/motors.html#motor-get-brake-mode>`_.
 
@@ -1389,7 +1389,7 @@ The default limit is 2500 mA.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_get_current_limit <../c/motors.html#motor-get-current-limit>`_.
 
@@ -1424,7 +1424,7 @@ Gets the encoder units set for the motor.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_get_encoder_units <../c/motors.html#motor-get-encoder-units>`_.
 
@@ -1456,7 +1456,7 @@ Gets the `gearset <motor_gearset_e_t_>`_` that was set for the motor.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_get_gearing <../c/motors.html#motor-get-gearing>`_.
 
@@ -1488,7 +1488,7 @@ Gets the voltage limit set by the user.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_get_voltage_limit <../c/motors.html#motor-get-voltage-limit>`_.
 
@@ -1522,7 +1522,7 @@ pros::Motor::set_pos_pid_full() functions have not been used.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Additionally, in an error state all values of the returned struct are set
 to their negative maximum values.
@@ -1572,7 +1572,7 @@ pros::Motor::set_vel_pid_full() functions have not been used.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Additionally, in an error state all values of the returned struct are set
 to their negative maximum values.
@@ -1620,7 +1620,7 @@ Gets the operation direction of the motor as set by the user.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_is_reversed <../c/motors.html#motor-is-reversed>`_.
 
@@ -1653,7 +1653,7 @@ Sets one of `motor_brake_mode_e_t`_ to the motor.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_set_brake_mode <../c/motors.html#motor-set-brake-mode>`_.
 
@@ -1694,7 +1694,7 @@ The default limit is 2500 mA.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_set_current_limit <../c/motors.html#motor-set-current-limit>`_.
 
@@ -1739,7 +1739,7 @@ Sets one of `motor_encoder_units_e_t`_ for the motor encoder.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_set_encoder_units <../c/motors.html#motor-set-encoder-units>`_.
 
@@ -1778,7 +1778,7 @@ Sets one of `motor_gearset_e_t <motor_gearset_e_t_>`_ for the motor.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_set_gearing <../c/motors.html#motor-set-gearing>`_.
 
@@ -1823,7 +1823,7 @@ Only non-zero values of the struct will change the existing motor constants.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_set_pos_pid <../c/motors.html#motor-set-pos-pid>`_.
 
@@ -1872,7 +1872,7 @@ Only non-zero values of the struct will change the existing motor constants.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_set_pos_pid_full <../c/motors.html#motor-set-pos-pid-full>`_.
 
@@ -1923,7 +1923,7 @@ This will invert its movements and the values returned for its position.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_set_reversed <../c/motors.html#motor-set-reversed>`_.
 
@@ -1968,7 +1968,7 @@ Only non-zero values of the struct will change the existing motor constants.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_set_vel_pid <../c/motors.html#motor-set-vel-pid>`_.
 
@@ -2017,7 +2017,7 @@ Only non-zero values of the struct will change the existing motor constants.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_set_vel_pid_full <../c/motors.html#motor-set-vel-pid-full>`_.
 
@@ -2066,7 +2066,7 @@ Sets the voltage limit for the motor in mV.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_set_voltage_limit <../c/motors.html#motor-set-voltage-limit>`_.
 
@@ -2113,7 +2113,7 @@ This will be the future reference point for the motor's "absolute" position.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_set_zero_position <../c/motors.html#motor-set-zero-position>`_.
 
@@ -2155,7 +2155,7 @@ Sets the "absolute" zero position of the motor to its current position.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
-- ``EACCES``  - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a motor
 
 Analogous to `motor_tare_position <../c/motors.html#motor-tare-position>`_.
 

--- a/v5/api/cpp/rtos.rst
+++ b/v5/api/cpp/rtos.rst
@@ -118,6 +118,37 @@ Creates a Task object from a task already created with the C API.
 
 ----
 
+.. tabs ::
+   .. tab :: Prototype
+      .. highlight:: cpp
+      ::
+
+        pros::Task::Task ( task_fn_t function, void* parameters = NULL, const char* name = "" )
+
+   .. tab :: Example
+      .. highlight:: cpp
+      ::
+
+        void my_task_fn(void* param) {
+          std::cout << "Hello" << (char*)param;
+          // ...
+        }
+        void initialize() {
+          pros::Task my_cpp_task (my_task_fn, (void*)"PROS", "My Task");
+        }
+
+Create a new task and add it to the list of tasks that are ready to run.
+
+=============== ===================================================================
+ Parameters
+=============== ===================================================================
+ function          Pointer to the task entry function
+ parameters        Pointer to memory that will be used as a parameter for the task being created. This memory should not typically come from stack, but rather from dynamically (i.e., malloc'd) or statically allocated memory.
+ name               A descriptive name for the task.  This is mainly used to facilitate debugging. The name may be up to 32 characters long.
+=============== ===================================================================
+
+----
+
 Operator Overloads
 ------------------
 
@@ -197,7 +228,7 @@ Delay a task until a specified time.  This function can be used by periodic
 tasks to ensure a constant execution frequency.
 
 The task will be woken up at the time ``*prev_time + delta``, and ``*prev_time`` will
-be updated to reflect the time at which the task will unblock. ``*prev_time`` should 
+be updated to reflect the time at which the task will unblock. ``*prev_time`` should
 be initialized to the result from `millis() <./rtos.html#millis>`_.
 
 Analogous to `task_delay_until <../c/rtos.html#delay-until>`_.
@@ -547,9 +578,9 @@ Analogous to `task_delete <../c/rtos.html#task-delete>`_.
             Task my_task (my_task_fn, NULL, TASK_PRIORITY_DEFAULT,
                           TASK_STACK_DEPTH_DEFAULT, "Example Task");
             // Do things
-            my_task.remove(); // Delete the task 
+            my_task.remove(); // Delete the task
             std::cout << "Task State: " << my_task.get_state() << std::endl;
-            // Prints the value of E_TASK_STATE_DELETED 
+            // Prints the value of E_TASK_STATE_DELETED
           }
 
 ----

--- a/v5/api/cpp/vision.rst
+++ b/v5/api/cpp/vision.rst
@@ -53,8 +53,8 @@ displaying the most prominent object signature color.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV``  - The port cannot be configured as a vision sensor
 
 .. tabs ::
    .. tab :: Prototype
@@ -152,8 +152,8 @@ for the additional function parameters.
 This function uses the following values of errno when an error state is
 reached:
 
-	- ``EINVAL`` - Fewer than two signatures have been provided, or one of the
-             		 signatures is out of its [1-7] range.
+	- ``EINVAL`` - Fewer than two signatures have been provided or one of the
+             		 signatures is out of its [1-7] range (or 0 when omitted).
 
 .. tabs ::
    .. tab :: Prototype
@@ -201,9 +201,10 @@ Gets the nth largest object of the given signature according to size_id.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a vision sensor
+- ``EINVAL``  - sig_id is outside the range [1-7]
 - ``EDOM`` - size_id is greater than the number of available objects.
-- ``EHOSTDOWN`` - Reading the vision sensor failed for an unknown reason.
+- ``EAGAIN`` - Reading the vision sensor failed for an unknown reason.
 
 .. tabs ::
    .. tab :: Prototype
@@ -252,9 +253,10 @@ Gets the nth largest object according to size_id.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a vision sensor
 - ``EDOM`` - size_id is greater than the number of available objects.
-- ``EHOSTDOWN`` - Reading the vision sensor failed for an unknown reason.
+- ``EAGAIN`` - Reading the vision sensor failed for an unknown reason.
+
 
 .. tabs ::
    .. tab :: Prototype
@@ -299,9 +301,8 @@ Gets the nth largest object of the given color code according to size_id.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EACCES`` - Another resource is currently trying to access the port.
-- ``EDOM`` - size_id is greater than the number of available objects.
-- ``EHOSTDOWN`` - Reading the vision sensor failed for an unknown reason.
+- ``ENODEV`` - The port cannot be configured as a vision sensor
+- ``EAGAIN`` - Reading the vision sensor failed for an unknown reason.
 
 .. tabs ::
    .. tab :: Prototype
@@ -351,8 +352,7 @@ Gets the exposure parameter of the Vision Sensor.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a vision sensor
 
 .. tabs ::
    .. tab :: Prototype
@@ -386,8 +386,7 @@ Returns the number of objects currently detected by the Vision Sensor.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a vision sensor
 
 .. tabs ::
    .. tab :: Prototype
@@ -421,7 +420,7 @@ Gets the object detection signature with the given id number.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a vision sensor
 
 .. tabs ::
    .. tab :: Prototype
@@ -461,8 +460,7 @@ Gets the white balance parameter of the Vision Sensor.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a vision sensor
 
 .. tabs ::
    .. tab :: Prototype
@@ -531,8 +529,10 @@ Reads up to object_count object descriptors into object_arr.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENXIO``  -  The given value is not within the range of V5 ports (1-21), or fewer than object_count number of objects were found.
+- ``ENODEV``  - The port cannot be configured as a vision sensor
 - ``EDOM`` - size_id is greater than the number of available objects.
+- ``EAGAIN`` - Reading the vision sensor failed for an unknown reason
 
 .. tabs ::
    .. tab :: Prototype
@@ -590,7 +590,8 @@ Reads up to object_count object descriptors into object_arr.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``EAGAIN``  -  Reading the vision sensor failed for an unknown reason
+- ``ENODEV``  - The port cannot be configured as a vision sensor
 - ``EDOM`` - size_id is greater than the number of available objects.
 
 .. tabs ::
@@ -646,9 +647,9 @@ Reads up to object_count object descriptors into object_arr.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EACCES`` - Another resource is currently trying to access the port.
-- ``EDOM`` - size_id is greater than the number of available objects.
-
+- ``ENXIO``  - The given value is not within the range of V5 ports (1-21), or fewer than object_count number of objects were found.
+- ``ENODEV``  - The port cannot be configured as a vision sensor
+- ``EAGAIN`` - Reading the vision sensor failed for an unknown reason.
 .. tabs ::
    .. tab :: Prototype
       .. highlight:: c
@@ -708,8 +709,7 @@ Enable/disable auto white-balancing on the Vision Sensor.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a vision sensor
 
 .. tabs ::
    .. tab :: Prototype
@@ -747,8 +747,7 @@ Sets the exposure parameter of the Vision Sensor.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a vision sensor
 
 .. tabs ::
    .. tab :: Prototype
@@ -788,8 +787,7 @@ Sets the vision sensor LED color, overriding the automatic behavior.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a vision sensor
 
 .. tabs ::
    .. tab :: Prototype
@@ -830,7 +828,8 @@ Stores the supplied object detection signature onto the vision sensor.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a vision sensor
+- ``EINVAL``  - sig_id is outside the range [1-7]
 
 .. tabs ::
    .. tab :: Prototype
@@ -875,8 +874,7 @@ This function will disable auto white-balancing.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a vision sensor
 
 .. tabs ::
    .. tab :: Prototype
@@ -919,8 +917,7 @@ function only be used to configure the sensor at the beginning of its use.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENODEV``  - The port cannot be configured as a vision sensor
 
 .. tabs ::
    .. tab :: Prototype
@@ -961,8 +958,7 @@ Set the Wi-Fi mode of the Vision Sensor.
 This function uses the following values of errno when an error state is
 reached:
 
-- ``EINVAL`` - The given value is not within the range of V5 ports (1-21).
-- ``EACCES`` - Another resource is currently trying to access the port.
+- ``ENODEV`` - The port cannot be configured as a vision sensor
 
 .. tabs ::
    .. tab :: Prototype

--- a/v5/getting-started/linux.rst
+++ b/v5/getting-started/linux.rst
@@ -7,6 +7,8 @@ Installing the toolchain
 
 1. Follow the instructions found `here <https://launchpad.net/~team-gcc-arm-embedded/+archive/ubuntu/ppa>`_ to add and install the latest version of the GNU Arm Embedded toolchain.
 
+.. note:: If you are using a Debian-based distribution of Linux of version >18.04, you can find the toolchain `here <https://www.ubuntuupdates.org/package/core/disco/universe/base/gcc-arm-none-eabi>`_.
+
 .. note:: If you are using a non-Debian-based distribution of Linux, check your favorite package repository for an updated version of the toolchain. The main requirement is that you get one that uses GCC version 7.2 or greater.
 
 Installing the CLI

--- a/v5/getting-started/linux.rst
+++ b/v5/getting-started/linux.rst
@@ -17,7 +17,7 @@ If you're not sure whether your distribution's package manager has the toolchain
 4. Close and re-open your terminal, or run :code:`source ~/.bashrc` (if running bash).
 5. Test by running :code:`arm-none-eabi-gcc --version`. The output should confirm that the version is greater than or equal to 7.2. If it is not, make sure you don't have conflicting versions installed through a package manager.
 
-.. note:: After installing the toolchain using the instructions listed above, upgrading to a newer version is as removing the previous install and following the instructions again with the newer version.
+.. note:: After installing the toolchain using the instructions listed above, upgrading to a newer version is as simple as removing the previous install and following the instructions again with the newer version.
 
 Installing the CLI
 ------------------

--- a/v5/getting-started/linux.rst
+++ b/v5/getting-started/linux.rst
@@ -13,7 +13,7 @@ Installing the CLI
 ------------------
 
 1. If you do not already have one installed, install a version of Python greater than or equal to 3.6
-2. Check the latest version of the PROS CLI on `our releases page <https://github.com/purduesigbots/pros-cli3/releases/latest>`_, and run :code:`python3.6 -m pip install --user https://github.com/purduesigbots/pros-cli3/releases/download/3.X.X/pros_cli_v5-3.X.X-py3-none-any.whl`, replacing the number after 'python' with the version you installed and the Xs with the numbers you found before. If you wish to install for all users, run the command with :code:`sudo` and remove the :code:`--user` flag.
+2. Check the latest version of the PROS CLI on `our releases page <https://github.com/purduesigbots/pros-cli3/releases/latest>`_, and run :code:`python3.6 -m pip install --user https://github.com/purduesigbots/pros-cli/releases/download/3.X.X/pros_cli_v5-3.X.X-py3-none-any.whl`, replacing the number after 'python' with the version you installed and the Xs with the numbers you found before. If you wish to install for all users, run the command with :code:`sudo` and remove the :code:`--user` flag.
 3. Run :code:`prosv5 --version` to verify the CLI was installed correctly. If the command doesn't work, try restarting your machine.
 
 Installing the Editor

--- a/v5/okapi/api/control/async/async-pos-integrated-controller.rst
+++ b/v5/okapi/api/control/async/async-pos-integrated-controller.rst
@@ -55,7 +55,7 @@ Methods
 setTarget
 ~~~~~~~~~
 
-Sets the target for the controller.
+Sets the target for the controller in the motor's encoder units.
 
 .. tabs ::
    .. tab :: Prototype
@@ -67,7 +67,7 @@ Sets the target for the controller.
 ============ ===============================================================
  Parameters
 ============ ===============================================================
- itarget      The new target.
+ itarget      The new target in the motor's encoder units.
 ============ ===============================================================
 
 ----

--- a/v5/okapi/api/control/async/async-vel-integrated-controller.rst
+++ b/v5/okapi/api/control/async/async-vel-integrated-controller.rst
@@ -36,7 +36,7 @@ Methods
 setTarget
 ~~~~~~~~~
 
-Sets the target for the controller.
+Sets the target for the controller in the motor's encoder units.
 
 .. tabs ::
    .. tab :: Prototype
@@ -48,7 +48,7 @@ Sets the target for the controller.
 ============ ===============================================================
  Parameters
 ============ ===============================================================
- itarget      The new target.
+ itarget      The new target in the motor's encoder units.
 ============ ===============================================================
 
 ----

--- a/v5/okapi/api/control/iterative/iterative-motor-velocity-controller.rst
+++ b/v5/okapi/api/control/iterative/iterative-motor-velocity-controller.rst
@@ -111,7 +111,7 @@ Gets the last set target, or the default target if none was set.
 setTarget
 ~~~~~~~~~
 
-Sets the target for the controller.
+Sets the target for the controller in the motor's encoder units.
 
 .. tabs ::
    .. tab :: Prototype
@@ -123,7 +123,7 @@ Sets the target for the controller.
 ============ ===============================================================
  Parameters
 ============ ===============================================================
- itarget      The new target.
+ itarget      The new target in the motor's encoder units.
 ============ ===============================================================
 
 ----

--- a/v5/okapi/api/device/motor/abstract-abstract-motor.rst
+++ b/v5/okapi/api/device/motor/abstract-abstract-motor.rst
@@ -1002,4 +1002,4 @@ to two wheel rotations, the ratio is ``1.0/2.0``.
         okapi::AbstractMotor::GearsetRatioPair foo = okapi::AbstractMotor::gearset::green;
 
         // You can also multiple a gearset by an external gear ratio
-        okapi::AbstractMotor::GearsetRatioPair foo = okapi::AbstractMotor::gearset::green * (2/3);
+        okapi::AbstractMotor::GearsetRatioPair foo = okapi::AbstractMotor::gearset::green * (2.0/3.0);

--- a/v5/okapi/tutorials/walkthrough/clawbot.rst
+++ b/v5/okapi/tutorials/walkthrough/clawbot.rst
@@ -11,11 +11,12 @@ Clawbot.
 Intended Audience:
 ==================
 
-This tutorial is intended for developers with some programming experience, but with little to no
-experience with the PROS library. If you haven't programmed before, we recommend checking out all
-the "Introduction and Basic C++ Features" sections of
-`this tutorial series <https://www.studytonight.com/cpp/introduction-to-cpp.php>`__; be sure to
-check out the "Classes and Objects" section as well.
+This tutorial is intended for developers with some programming experience, but
+with little to no experience with the PROS library. If you haven't programmed
+before, we recommend checking out all the "Introduction and Basic C++ Features"
+sections of `this tutorial series
+<https://www.studytonight.com/cpp/introduction-to-cpp.php>`__; be sure to check
+out the "Classes and Objects" section as well.
 
 Goals:
 ======
@@ -94,25 +95,30 @@ The last 3 commands can be simplified to :code:`prosv5 mut`.
 Tank/Arcade Control
 -------------------
 
-OkapiLib uses something called a
-`ChassisController <../../api/chassis/controller/abstract-chassis-controller.html>`_
-to interact with a robot's chassis. This interface lets you use open-loop control methods to drive
-the robot around with a joystick, like tank and arcade control. It also provides methods to move
-the robot programmatically, like driving in an arc or only powering one side of the chassis. It
-also provides closed-loop control methods to drive a specific distance or turn a specific angle.
+OkapiLib uses something called a `ChassisController
+<../../api/chassis/controller/abstract-chassis-controller.html>`_ to interact
+with a robot's chassis. This interface lets you use open-loop control methods
+to drive the robot around with a joystick, like tank and arcade control. It
+also provides methods to move the robot programmatically, like driving in an
+arc or only powering one side of the chassis. It also provides closed-loop
+control methods to drive a specific distance or turn a specific angle.
 
-There are two main subclasses we can use:
-`ChassisControllerIntegrated <../../api/chassis/controller/chassis-controller-integrated.html>`_
-and `ChassisControllerPID <../../api/chassis/controller/chassis-controller-pid.html>`_.
-`ChassisControllerIntegrated <../../api/chassis/controller/chassis-controller-integrated.html>`_
-uses the V5 motor's built-in position and velocity control to move the robot around. **This class
-is the easiest to use**, and should be used by default. The other class,
-`ChassisControllerPID <../../api/chassis/controller/chassis-controller-pid.html>`_, uses two PID
+There are two main subclasses we can use: `ChassisControllerIntegrated
+<../../api/chassis/controller/chassis-controller-integrated.html>`_ and
+`ChassisControllerPID
+<../../api/chassis/controller/chassis-controller-pid.html>`_.
+`ChassisControllerIntegrated
+<../../api/chassis/controller/chassis-controller-integrated.html>`_ uses the V5
+motor's built-in position and velocity control to move the robot around. **This
+class is the easiest to use**, and should be used by default. The other class,
+`ChassisControllerPID
+<../../api/chassis/controller/chassis-controller-pid.html>`_, uses two PID
 controllers running on the V5 brain and sends velocity commands to the motors.
 
-We will be using
-`ChassisControllerIntegrated <../../api/chassis/controller/chassis-controller-integrated.html>`_
-for this tutorial. Let's initialize it now with our two motors in ports ``1`` and ``10``.
+We will be using `ChassisControllerIntegrated
+<../../api/chassis/controller/chassis-controller-integrated.html>`_ for this
+tutorial. Let's initialize it with our two motors in ports ``1`` and ``10``,
+with the motor in port ``1`` reversed.
 
 .. highlight:: cpp
 .. code-block:: cpp
@@ -121,14 +127,14 @@ for this tutorial. Let's initialize it now with our two motors in ports ``1`` an
    using namespace okapi;
 
    // Chassis Controller - lets us drive the robot around with open- or closed-loop control
-   auto drive = ChassisControllerFactory::create(1, 10);
+   auto drive = ChassisControllerFactory::create(-1, 10);
 
-Next, let's setup tank or arcade control.
-`ChassisController <../../api/chassis/controller/abstract-chassis-controller.html>`_ provides
-methods for us
-to use, we just need to pass in joystick values which have been scaled to be in the range
-``[-1, 1]``. OkapiLib's `Controller <../../api/device/controller.html>`_ returns analog values in the
-range ``[-1, 1]``, so we don't need to do any division ourselves.
+Next, let's setup tank or arcade control. `ChassisController
+<../../api/chassis/controller/abstract-chassis-controller.html>`_ provides
+methods for us to use, we just need to pass in joystick values which have been
+scaled to be in the range ``[-1, 1]``. OkapiLib's `Controller
+<../../api/device/controller.html>`_ returns analog values in the range ``[-1,
+1]``, so we don't need to do any division ourselves.
 
 .. tabs ::
    .. tab :: Tank drive
@@ -138,16 +144,16 @@ range ``[-1, 1]``, so we don't need to do any division ourselves.
 
          // Joystick to read analog values for tank or arcade control.
          // Master controller by default.
-         Controller controller;
+         Controller masterController;
 
          while (true) {
            // Tank drive with left and right sticks.
-           drive.tank(controller.getAnalog(controllerAnalog::leftY),
-                      controller.getAnalog(controllerAnalog::rightY));
+           drive.tank(masterController.getAnalog(ControllerAnalog::leftY),
+                      masterController.getAnalog(ControllerAnalog::rightY));
 
            // Wait and give up the time we don't need to other tasks.
            // Additionally, joystick values, motor telemetry, etc. all updates every 10 ms.
-           pros::Task::delay(10);
+           pros::delay(10);
          }
 
    .. tab :: Arcade drive
@@ -157,29 +163,30 @@ range ``[-1, 1]``, so we don't need to do any division ourselves.
 
          // Joystick to read analog values for tank or arcade control.
          // Master controller by default.
-         Controller controller;
+         Controller masterController;
 
          while (true) {
            // Arcade drive with the left stick.
-           drive.arcade(controller.getAnalog(controllerAnalog::leftY),
-                        controller.getAnalog(controllerAnalog::leftX));
+           drive.arcade(masterController.getAnalog(ControllerAnalog::leftY),
+                        masterController.getAnalog(ControllerAnalog::leftX));
 
            // Wait and give up the time we don't need to other tasks.
            // Additionally, joystick values, motor telemetry, etc. all updates every 10 ms.
-           pros::Task::delay(10);
+           pros::delay(10);
          }
 
 Arm Control
 -----------
 
-This section will focus on controlling the clawbot's arm. There are two parts to this: first, the
-arm has a limit switch at the bottom of its travel range, so we should use that button to tell when
-we've hit a hard stop; second, the arm should be user-controlled with two buttons on the
-controller.
+This section will focus on controlling the clawbot's arm. There are two parts
+to this: first, the arm has a limit switch at the bottom of its travel range,
+so we should use that button to tell when we've hit a hard stop; second, the
+arm should be user-controlled with two buttons on the controller.
 
-First, let's focus on the limit switch at the bottom of the arm's travel range. When the arm hits
-this button, the arm motor should stop trying to make the arm move down. We can accomplish this
-using an if-statement that checks whether the button is pressed.
+First, let's focus on the limit switch at the bottom of the arm's travel range.
+When the arm hits this button, the arm motor should stop trying to make the arm
+move down. We can accomplish this using an if-statement that checks whether the
+button is pressed.
 
 We can define our button as an `ADIButton <../../api/device/button/adi-button.html>`_:
 
@@ -195,8 +202,9 @@ And the arm motor:
 
    Motor armMotor = 8_rmtr;
 
-The ``_mtr`` syntax is called a user-defined literal. It's a succinct way of initializing a motor,
-and is equivalent to calling the normal constructor. For example,
+The ``_mtr`` syntax is called a user-defined literal. It's a succinct way of
+initializing a motor, and is equivalent to calling the normal constructor. For
+example,
 
 .. highlight:: cpp
 .. code-block:: cpp
@@ -219,8 +227,8 @@ Then we can check if it's pressed and stop powering the arm motor:
      // Normal arm control
    }
 
-Next, let's add the logic to make the arm user-controller with two buttons on the controller.
-First, we need to define our two controller buttons as
+Next, let's add the logic to make the arm user-controller with two buttons on
+the controller. First, we need to define our two controller buttons as
 `ControllerButton <../../api/device/button/controller-button.html>`_ instances:
 
 .. highlight:: cpp
@@ -229,7 +237,8 @@ First, we need to define our two controller buttons as
    ControllerButton armUpButton(ControllerDigital::A);
    ControllerButton armDownButton(ControllerDigital::B);
 
-Then we can use them along with our limit switch logic from above to control the arm:
+Then we can use them along with our limit switch logic from above to control
+the arm:
 
 .. highlight:: cpp
 .. code-block:: cpp
@@ -241,28 +250,31 @@ Then we can use them along with our limit switch logic from above to control the
    } else {
      // Else, the arm isn't all the way down
      if (armUpButton.isPressed()) {
-       armMotor.moveVoltage(12000);
+       armMotor.moveVoltage(12000); // 12,000 millivolts
      } else if (armDownButton.isPressed()) {
-       armMotor.moveVoltage(-12000);
+       armMotor.moveVoltage(-12000); // -12,000 millivolts
      } else {
-       armMotor.moveVoltage(0);
+       armMotor.moveVoltage(0); // 0 millivolts, the motor will coast
      }
    }
 
 Autonomous Routine
 ------------------
 
-To illustrate the closed-loop control method that
-`ChassisController <../../api/chassis/controller/abstract-chassis-controller.html>`_ has, let's make a
-simple autonomous routine to drive in a square.
+To illustrate the closed-loop control method that `ChassisController
+<../../api/chassis/controller/abstract-chassis-controller.html>`_ has, let's
+make a simple autonomous routine to drive in a square.
 
-Writing an autonomous routine is much easier when distances and turns can be done
-with real life units, so let's configure the `ChassisController <../../api/chassis/controller/abstract-chassis-controller.html>`_
-with the clawbot chassis's dimensions. This will require a change to the drive's
+Writing an autonomous routine is much easier when distances and turns can be
+done with real life units, so let's configure the `ChassisController
+<../../api/chassis/controller/abstract-chassis-controller.html>`_ with the
+clawbot chassis's dimensions. This will require a change to the drive's
 constructors; two additional parameters are needed. The first is the gearset of
-the motors on the chassis, in this example we will use the standard Green cartridges.
-The second is a `list <http://www.cplusplus.com/reference/initializer_list/initializer_list/>`_
-containing firstly the wheel diameter (4") and secondly, the width of the chassis (11.5").
+the motors on the chassis, in this example we will use the standard Green
+cartridges. The second is a `list
+<http://www.cplusplus.com/reference/initializer_list/initializer_list/>`_
+containing firstly the wheel diameter (4") and secondly, the width of the wheel
+track (11.5").
 
 .. highlight:: cpp
 .. code-block:: cpp
@@ -275,7 +287,8 @@ containing firstly the wheel diameter (4") and secondly, the width of the chassi
      {4_in, 11.5_in}
    );
 
-After this, you can move the chassis in actual units, such as inches and degrees.
+After this, you can move the chassis in actual units, such as inches and
+degrees.
 
 .. highlight:: cpp
 .. code-block:: cpp
@@ -310,7 +323,7 @@ This is the final product from this tutorial.
          void opcontrol() {
            // Joystick to read analog values for tank or arcade control
            // Master controller by default
-           Controller controller;
+           Controller masterController;
 
            // Arm related objects
            ADIButton armLimitSwitch('H');
@@ -323,8 +336,8 @@ This is the final product from this tutorial.
 
            while (true) {
              // Tank drive with left and right sticks
-             drive.tank(controller.getAnalog(ControllerAnalog::leftY),
-                        controller.getAnalog(ControllerAnalog::rightY));
+             drive.tank(masterController.getAnalog(ControllerAnalog::leftY),
+                        masterController.getAnalog(ControllerAnalog::rightY));
 
              // Don't power the arm if it is all the way down
              if (armLimitSwitch.isPressed()) {
@@ -351,7 +364,7 @@ This is the final product from this tutorial.
 
              // Wait and give up the time we don't need to other tasks.
              // Additionally, joystick values, motor telemetry, etc. all updates every 10 ms.
-             pros::Task::delay(10);
+             pros::delay(10);
            }
          }
 
@@ -373,7 +386,7 @@ This is the final product from this tutorial.
          void opcontrol() {
            // Joystick to read analog values for tank or arcade control
            // Master controller by default
-           Controller controller;
+           Controller masterController;
 
            // Arm related objects
            ADIButton armLimitSwitch('H');
@@ -386,8 +399,8 @@ This is the final product from this tutorial.
 
            while (true) {
              // Arcade drive with the left stick
-             drive.arcade(controller.getAnalog(ControllerAnalog::leftY),
-                          controller.getAnalog(ControllerAnalog::rightY));
+             drive.arcade(masterController.getAnalog(ControllerAnalog::leftY),
+                          masterController.getAnalog(ControllerAnalog::rightY));
 
              // Don't power the arm if it is all the way down
              if (armLimitSwitch.isPressed()) {
@@ -414,6 +427,6 @@ This is the final product from this tutorial.
 
              // Wait and give up the time we don't need to other tasks.
              // Additionally, joystick values, motor telemetry, etc. all updates every 10 ms.
-             pros::Task::delay(10);
+             pros::delay(10);
            }
          }

--- a/v5/okapi/tutorials/walkthrough/clawbot.rst
+++ b/v5/okapi/tutorials/walkthrough/clawbot.rst
@@ -245,7 +245,7 @@ Then we can use them along with our limit switch logic from above to control the
      } else if (armDownButton.isPressed()) {
        armMotor.moveVoltage(-12000);
      } else {
-       armMotor.move_voltage(0);
+       armMotor.moveVoltage(0);
      }
    }
 
@@ -328,15 +328,15 @@ This is the final product from this tutorial.
 
              // Don't power the arm if it is all the way down
              if (armLimitSwitch.isPressed()) {
-               armMotor.move_voltage(0);
+               armMotor.moveVoltage(0);
              } else {
                // Else, the arm isn't all the way down
                if (armUpButton.isPressed()) {
-                 armMotor.move_voltage(127);
+                 armMotor.moveVoltage(12000);
                } else if (armDownButton.isPressed()) {
-                 armMotor.move_voltage(-127);
+                 armMotor.moveVoltage(-12000);
                } else {
-                 armMotor.move_voltage(0);
+                 armMotor.moveVoltage(0);
                }
              }
 

--- a/v5/okapi/tutorials/walkthrough/getting-started.rst
+++ b/v5/okapi/tutorials/walkthrough/getting-started.rst
@@ -21,7 +21,7 @@ using it by uncommenting OkapiLib's API header include statement in the file ``i
     #include "okapi/api.hpp"
     //#include "pros/api_legacy.h"
 
-Then, in file ``src/opcontrol.cpp``, remove the statement ``using namespace pros::literals``.
+Then, in file ``src/opcontrol.cpp``, remove the statement ``using namespace pros::literals`` (if it exists).
 
 That's it! Take a look at the `other tutorials <../index.html>`_ to get a better understanding
 of the tools Okapilib has.

--- a/v5/releases/cli3.1.4.rst
+++ b/v5/releases/cli3.1.4.rst
@@ -24,7 +24,7 @@ Run ``pip install https://github.com/purduesigbots/pros-cli/releases/download/3.
 Windows
 -------
 
-Download and run the appropriate installer from `our release page <https://github.com/purduesigbots/pros-cli/releases/3.1.4>`_.
+Download and run the appropriate (.exe) installer from `our release page <https://github.com/purduesigbots/pros-cli/releases/3.1.4>`_.
 
 macOS
 -----

--- a/v5/releases/kernel3.2.0.rst
+++ b/v5/releases/kernel3.2.0.rst
@@ -2,7 +2,7 @@
 PROS Kernel 3.2.0 Release
 =========================
 
-.. post:: 7 September, 2019
+.. post:: 18 September, 2019
    :tags: blog, kernel-release
 
 Important upgrade notes

--- a/v5/releases/kernel3.2.0.rst
+++ b/v5/releases/kernel3.2.0.rst
@@ -1,0 +1,42 @@
+=========================
+PROS Kernel 3.2.0 Release
+=========================
+
+.. post:: 7 September, 2019
+   :tags: blog, kernel-release
+
+Important upgrade notes
+-----------------------
+
+We are replacing the three :code:`initialize.cpp`, :code:`autonomous.cpp`, and :code:`opcontrol.cpp` files with a single :code:`main.cpp` file (see below) for new projects, so the :code:`main.cpp` file will be introduced into your project when you upgrade. If you compile the project right away, you will likely be faced with multiple definition errors for the competition tasks. To resolve this, you can either delete the new :code:`main.cpp`, or move the contents of your competition task functions into the new file, deleting the previous files. If your project structure has been significantly modified from the default, we trust that you will know how to resolve this issue on your own. Also note that if you have already consolidated the three files listed above into a single :code:`main.cpp` file, this will not be an issue.
+
+If your code checked :code:`errno` values set by PROS functions, you may need to change the values you compare with. Check each function's documentation for more information.
+
+We have upgraded LVGL to 5.3, but since starting the upgrade process LVGL 6.0 was released, which has changed things a lot, and the online documentation for LVGL now reflects information for version 6.0. Please see `this link <https://docs.littlevgl.com/en/html/index.html#where-can-i-find-the-documentation-of-the-previous-version-v5-3>`_ for information on where to find the documentation for LVGL 5.3.
+
+Changelog
+---------
+
+New Features:
+
+- Upgrade LVGL to version 5.3
+- Add an alternate :code:`pros::Task` constructor that takes only a task function, parameters, and a name.
+- Add an alternate API for generic serial communications over the smart ports
+- Add a better data abort handler that prints a stack trace
+
+Usability Improvements:
+
+- Add Makefile variable for excluding libraries from the cold image
+- Improve Makefile compile speed
+- Support GCC 8.3 out of the box
+- Add a default .gitignore to new projects
+- Changes in header files will now be recompiled without having to clean
+- Replace separate :code:`initialize.cpp`, :code:`autonomous.cpp`, and :code:`opcontrol.cpp` files with a single :code:`main.cpp` file for new projects
+
+Bugfixes:
+
+- Make :code:`vision_read_by_sig` properly transform coordinates and respect array boundaries
+- Make VDML/ADI :code:`errno` values more consistent
+- Other assorted VDML/ADI bugfixes
+- Fix generic serial communications driver
+- Fix C++ file I/O

--- a/v5/releases/kernel3.2.0.rst
+++ b/v5/releases/kernel3.2.0.rst
@@ -10,6 +10,8 @@ Important upgrade notes
 
 We are replacing the three :code:`initialize.cpp`, :code:`autonomous.cpp`, and :code:`opcontrol.cpp` files with a single :code:`main.cpp` file (see below) for new projects, so the :code:`main.cpp` file will be introduced into your project when you upgrade. If you compile the project right away, you will likely be faced with multiple definition errors for the competition tasks. To resolve this, you can either delete the new :code:`main.cpp`, or move the contents of your competition task functions into the new file, deleting the previous files. If your project structure has been significantly modified from the default, we trust that you will know how to resolve this issue on your own. Also note that if you have already consolidated the three files listed above into a single :code:`main.cpp` file, this will not be an issue.
 
+You may also get multiple definition errors if you added the temporary :code:`__sync_synchronize` fix that was necessary for some users. After upgrading, you may safely remove that fix from your own code.
+
 If your code checked :code:`errno` values set by PROS functions, you may need to change the values you compare with. Check each function's documentation for more information.
 
 We have upgraded LVGL to 5.3, but since starting the upgrade process LVGL 6.0 was released, which has changed things a lot, and the online documentation for LVGL now reflects information for version 6.0. Please see `this link <https://docs.littlevgl.com/en/html/index.html#where-can-i-find-the-documentation-of-the-previous-version-v5-3>`_ for information on where to find the documentation for LVGL 5.3.

--- a/v5/tutorials/general/coding-faq.rst
+++ b/v5/tutorials/general/coding-faq.rst
@@ -2,6 +2,16 @@
 Coding FAQ
 ==========
 
+    * ``"main.h" file not found``:
+        This error occurs when the compilation database ``compile_commands.json``
+        is not up to date. The file contains the exact compiler calls of the project, and should be automatically populated when the code is compiled.
+        If you see this error just after creating a project, it could be because the project was created
+        using the CLI without the ``–compile-after`` flag, or there was a hang-up in the
+        editor after creating the project. Regardless of when this issue appears, running ``pros make all`` in the CLI or
+        running ``PROS -> Build -> All`` in the editor, the whole project is compiled again, fixing this
+        issue. You may need to close and reopen any files in order for the linter to catch up. It is also possible that a compilation error was not caught by the linter, so running
+        a full build will help discover these hidden errors.
+    
 Compile-Time Issues
 ===================
 

--- a/v5/tutorials/general/project-structure.rst
+++ b/v5/tutorials/general/project-structure.rst
@@ -50,11 +50,12 @@ src
 ===
 
 **User code** has the actual sequential instructions that govern the
-robot's behavior. PROS by default splits the user code up into
+robot's behavior. Prior to PROS kernel 3.2.0, new projects by default split user code into
 autonomous (``autonomous.c`` or ``autonomous.cpp``), driver control
 (``opcontrol.c`` or ``opcontrol.cpp``), and initialization
 (``initialize.c`` or ``initialize.cpp``) files. Code in one file can talk to code in
-another file using declarations in the header files.
+another file using declarations in the header files. Beginning with PROS kernel 3.2.0, new projects by
+default have a single ``main.cpp`` file that contains all of the competition task functions.
 
 New user code files can be created in the ``src`` directory, as long as the name
 ends with ``.c`` or ``.cpp`` it will be compiled with the others.

--- a/v5/tutorials/topical/display.rst
+++ b/v5/tutorials/topical/display.rst
@@ -5,7 +5,7 @@ V5 Brain Display (LVGL)
 Interacting with the touchscreen on the V5 Brain is made possible through `LVGL <https://littlevgl.com>`_.
 LVGL is a full-featured C graphics library (it's accessible in C++ projects too under the same API).
 
-The first step to getting started with LVGL is to include ``apix.h`` in your ``main.h`` file or other header files.
+The first step to getting started with LVGL is to include ``pros/apix.h`` in your ``main.h`` file or other header files.
 This includes the full LVGL feature set as described in their documentation: https://littlevgl.com/
 
 You can follow along with any of the LVGL `tutorials <https://github.com/littlevgl/lv_examples/tree/master/lv_tutorial>`_

--- a/v5/tutorials/topical/filesystem.rst
+++ b/v5/tutorials/topical/filesystem.rst
@@ -18,7 +18,7 @@ in the following manner:
 .. code-block:: cpp
 
    FILE* usd_file_write = fopen("/usd/example.txt", "w");
-   fputs("Example text", usd_fil_write);
+   fputs("Example text", usd_file_write);
    fclose(usd_file_write);
 
    FILE* usd_file_read = fopen("/usd/example.txt", "r");

--- a/v5/tutorials/topical/filesystem.rst
+++ b/v5/tutorials/topical/filesystem.rst
@@ -2,18 +2,17 @@
 Filesystem
 ==========
 
-You can interact with files on the V5 brain and the microSD card through standard
-C/C++ file I/O methods. For the most part, you can follow along with any standard C
-tutorial for file I/O and it will work with PROS. Here are a couple of recommended
+You can interact with files on the microSD card (you can **not** interact with files on the V5
+brain's flash) through standard C/C++ file I/O methods. For the most part, you can follow along with
+any standard C tutorial for file I/O and it will work with PROS. Here are a couple of recommended
 tutorials:
 
 - https://www.cprogramming.com/tutorial/cfileio.html
 - https://www.tutorialspoint.com/cprogramming/c_file_io.htm
 
-The only additional detail needed for interacting with the filesystem in PROS is
-that any files on the microSD card need to be prefaced with ``/usd/`` to distinguish
-them from files on the V5 Brain. A file on the microSD card can be written to in the
-following manner:
+The only additional detail needed for interacting with the filesystem in PROS is that any files on
+the microSD card **must** be prefaced with ``/usd/``. A file on the microSD card can be written to
+in the following manner:
 
 .. highlight: cpp
 .. code-block:: cpp

--- a/v5/tutorials/topical/multitasking.rst
+++ b/v5/tutorials/topical/multitasking.rst
@@ -75,7 +75,7 @@ Tasks in PROS are simple to create:
             }
             void initialize() {
                 std::string text("PROS");
-                Task my_task(my_task_fn, &text);
+                Task my_task(my_task_fn, &text, "");
             }
     .. tab :: API2
         .. highlight:: c

--- a/v5/tutorials/topical/wireless-upload.rst
+++ b/v5/tutorials/topical/wireless-upload.rst
@@ -22,7 +22,7 @@ To enable this compilation mode, you should open your project's Makefile and edi
 so that ``USE_PACKAGE:=1``. Re-build and upload your project and PROS will automatically use the new files. PROS
 will automatically detect when you're using the same combination of libraries and decide not to re-upload the
 "cold" code. Verification that the library is present is done with filename and checksum of the file. As a result,
-if you use the same combination of libraries (cold image), only one copy of the cold iamge is uploaded to the V5.
+if you use the same combination of libraries (cold image), only one copy of the cold image is uploaded to the V5.
 
 Large Projects
 --------------

--- a/v5/tutorials/walkthrough/clawbot.rst
+++ b/v5/tutorials/walkthrough/clawbot.rst
@@ -104,37 +104,62 @@ PROS Project Structure
 When you create your project, PROS will copy all of the files necessary
 to build your project. The structure of the project looks like:
 
-.. highlight:: none
+.. tabs ::
+   .. group-tab :: After 3.2.0
+      .. highlight:: none
+      ::
 
-::
+         project
+         │   project.pros        (used by PROS CLI to know kernel version and other metadata)
+         │   Makefile            (instructs make how to compile your project)
+         |   common.mk           (helper file for Makefile)
+         │
+         └───src                 (source files should go here)
+         │   │   main.cpp        (source for competition task functions, like operator control and autonomous)
+         |
+         └───include             (Header files should go in here)
+         │   │   api.h           (Lets source files know PROS API functions)
+         │   │   main.h          (Includes api.h and anything else you want to include project-wide)
+         |   └───pros            (Contains all of the specific header files for the PROS API functions)
+         |   └───okapi           (Contains all of the header files for OkapiLib)
+         |   └───display         (Contains all of the header files for LVGL, the graphics library for the V5 screen)
+         │
+         └───firmware
+         │   libpros.a       (Pre-compiled PROS library)
+         │   okapilib.a      (Pre-compiled OkapiLib library)
+         |   v5.ld           (Instructs the linker how to construct binaries for the V5)
 
-  project
-  │   project.pros        (used by PROS CLI to know kernel version and other metadata)
-  │   Makefile            (instructs make how to compile your project)
-  |   common.mk           (helper file for Makefile)
-  │
-  └───src                 (source files should go here)
-  │   │   autonomous.cpp  (source for autonomous function)
-  │   │   initialize.cpp  (source for initialization)
-  │   │   opcontrol.cpp   (source for operator control)
-  |
-  └───include             (Header files should go in here)
-  │   │   api.h           (Lets source files know PROS API functions)
-  │   │   main.h          (Includes api.h and anything else you want to include project-wide)
-  |   └───pros            (Contains all of the specific header files for the PROS API functions)
-  |   └───okapi           (Contains all of the header files for OkapiLib)
-  |   └───display         (Contains all of the header files for LVGL, the graphics library for the V5 screen)
-  │
-  └───firmware 
-      │   libpros.a       (Pre-compiled PROS library)
-      │   okapilib.a      (Pre-compiled OkapiLib library)
-      |   v5.ld           (Instructs the linker how to construct binaries for the V5)
+   .. group-tab :: Before 3.2.0
+      .. highlight:: none
+      ::
+
+         project
+         │   project.pros        (used by PROS CLI to know kernel version and other metadata)
+         │   Makefile            (instructs make how to compile your project)
+         |   common.mk           (helper file for Makefile)
+         │
+         └───src                 (source files should go here)
+         │   │   autonomous.cpp  (source for autonomous function)
+         │   │   initialize.cpp  (source for initialization)
+         │   │   opcontrol.cpp   (source for operator control)
+         |
+         └───include             (Header files should go in here)
+         │   │   api.h           (Lets source files know PROS API functions)
+         │   │   main.h          (Includes api.h and anything else you want to include project-wide)
+         |   └───pros            (Contains all of the specific header files for the PROS API functions)
+         |   └───okapi           (Contains all of the header files for OkapiLib)
+         |   └───display         (Contains all of the header files for LVGL, the graphics library for the V5 screen)
+         │
+         └───firmware
+         │   libpros.a       (Pre-compiled PROS library)
+         │   okapilib.a      (Pre-compiled OkapiLib library)
+         |   v5.ld           (Instructs the linker how to construct binaries for the V5)
 
 
 .. note::
-   By convention, the ``opcontrol()``, ``autonomous()``, and initialize functions are separated into separate 
-   files (opcontrol.cpp, autonomous.cpp, and initialize.cpp). They could be all in the same file, but it can be helpful to 
-   organize your functions into multiple files to keep things from becoming messy.
+   Prior to PROS kernel 3.2.0, the ``opcontrol()``, ``autonomous()``, and initialize functions are separated into separate 
+   files (opcontrol.cpp, autonomous.cpp, and initialize.cpp). After PROS kernel 3.2.0, they are by default kept in one file
+   (main.cpp). These could be separated again if you so wish.
 
 Drive Control 
 =============
@@ -190,7 +215,7 @@ and then we'll run the tank drive code.
    .. group-tab :: C++
       .. highlight:: cpp
       .. code-block:: cpp
-         :caption: opcontrol.cpp 
+         :caption: main.cpp 
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -212,7 +237,7 @@ and then we'll run the tank drive code.
    .. group-tab :: C
       .. highlight:: c
       .. code-block:: c
-         :caption: opcontrol.c
+         :caption: main.c
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -255,7 +280,7 @@ wheels.
    .. group-tab :: C++
       .. highlight:: cpp
       .. code-block:: cpp
-         :caption: opcontrol.cpp 
+         :caption: main.cpp 
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -281,7 +306,7 @@ wheels.
    .. group-tab :: C
       .. highlight:: c
       .. code-block:: c
-         :caption: opcontrol.c
+         :caption: main.c
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -354,7 +379,7 @@ is pressed on the controller, and move the lift in that direction if so.
    .. group-tab :: C++
       .. highlight:: cpp
       .. code-block:: cpp
-         :caption: opcontrol.cpp 
+         :caption: main.cpp 
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -392,7 +417,7 @@ is pressed on the controller, and move the lift in that direction if so.
    .. group-tab :: C
       .. highlight:: c
       .. code-block:: c
-         :caption: opcontrol.c
+         :caption: main.c
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -434,7 +459,7 @@ We will control the claw in the same manner as the lift, by toggling its movemen
    .. group-tab :: C++
       .. highlight:: cpp
       .. code-block:: cpp
-         :caption: opcontrol.cpp 
+         :caption: main.cpp 
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -484,7 +509,7 @@ We will control the claw in the same manner as the lift, by toggling its movemen
    .. group-tab :: C
       .. highlight:: c
       .. code-block:: c
-         :caption: opcontrol.c
+         :caption: main.c
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -558,7 +583,7 @@ And here is the updated code:
    .. group-tab :: C++
       .. highlight:: cpp
       .. code-block:: cpp
-         :caption: opcontrol.cpp 
+         :caption: main.cpp 
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -625,7 +650,7 @@ And here is the updated code:
    .. group-tab :: C
       .. highlight:: c
       .. code-block:: c
-         :caption: opcontrol.c
+         :caption: main.c
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -693,7 +718,7 @@ we will prevent the lift from being driven down further.
    .. group-tab :: C++
       .. highlight:: cpp
       .. code-block:: cpp
-         :caption: opcontrol.cpp 
+         :caption: main.cpp 
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -762,7 +787,7 @@ we will prevent the lift from being driven down further.
    .. group-tab :: C
       .. highlight:: c
       .. code-block:: c
-         :caption: opcontrol.c
+         :caption: main.c
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -834,7 +859,7 @@ The autonomous program runs without the use of a controller. We will make a simp
    .. group-tab :: C++
       .. highlight:: cpp
       .. code-block:: cpp
-         :caption: autonomous.cpp 
+         :caption: main.cpp 
          :linenos:
 
          #define LEFT_WHEELS_PORT 1
@@ -852,7 +877,7 @@ The autonomous program runs without the use of a controller. We will make a simp
    .. group-tab :: C
       .. highlight:: c
       .. code-block:: c
-         :caption: autonomous.c
+         :caption: main.c
          :linenos:
 
          #define LEFT_WHEELS_PORT 1

--- a/v5/tutorials/walkthrough/creating-c-project.rst
+++ b/v5/tutorials/walkthrough/creating-c-project.rst
@@ -3,8 +3,8 @@ Creating a C Project
 ====================
 
 By default, a new PROS project contains C++ source files and the C++ API. If you would prefer to program in C
-instead, change the extension of the source files (``initialize.cpp``, ``autonomous.cpp``, and ``opcontrol.cpp``)
-to ``.c``. 
+instead, change the extension of the source files (prior to PROS kernel 3.2.0: ``initialize.cpp``, ``autonomous.cpp``,
+and ``opcontrol.cpp``; after PROS kernel 3.2.0: ``main.cpp``) to ``.c``. 
 
 .. warning:: Do not change any of the PROS header files in this process. That will cause the wrong files to be
              included in your project, and will likely prevent compilation. Only modify the extensions of the ``.cpp`` files.


### PR DESCRIPTION
On https://pros.cs.purdue.edu/v5/contact.html The link to the supposed slack group has expired [Old Link](https://pros-development.slack.com/join/shared_invite/enQtMzIyNzA2MTU2MDgwLWNlNTk3ZjA3ZWZmM2Q0YzI3NDZkZWE0MzU4ODdkM2U5MzhjZDY4M2RjNzBiZWYzODk0MTdkYzBiMzJjMWUyYmI)

this replacement link does the trick [New Link](https://join.slack.com/t/pros-development/shared_invite/enQtMzIyNzA2MTU2MDgwLWUwYzRhODRkYjU5ZmM5OTFhOWQxNjc4MzQ1OTc0MjU0MGFiMDdlMTQ3YTdhNDc2ZDU3NjcyZjM4MDgwNGMzOGE)

