### PR TITLE
Add sd card formatting requirement

### DIFF
--- a/v5/tutorials/topical/filesystem.rst
+++ b/v5/tutorials/topical/filesystem.rst
@@ -28,6 +28,11 @@ in the following manner:
    // Should print "Example text" to the terminal
    fclose(usd_file_read); // always close files when you're done with them
 
+Remarks
+-------
+
+The microSD card must be fat32 in order to work.
+
 Serial
 ======
 


### PR DESCRIPTION
Currently, we don't have the format the SD Card needs to be in anywhere in the docs, so add it. The tutorial section isn't the best place for it, but we don't really touch this anywhere else that I know of.