### PR TITLE
Fixed IMU documentation to change reset function example

### DIFF
--- a/v5/api/cpp/imu.rst
+++ b/v5/api/cpp/imu.rst
@@ -74,7 +74,7 @@ This function uses the following values of ``errno`` when an error state is reac
           
           int time = pros::millis();
           int iter = 0;
-          while (imu_sensor.get_status()) {
+          while (imu_sensor.is_calibrating()) {
             printf("IMU calibrating... %d\n", iter);
             iter += 10;
             pros::delay(10);

--- a/v5/api/cpp/imu.rst
+++ b/v5/api/cpp/imu.rst
@@ -514,7 +514,7 @@ This function uses the following values of ``errno`` when an error state is reac
 	        imu_sensor.reset();
 	        int time = pros::millis();
 	        int iter = 0;
-	        while (imu_sensor.get_status()) {
+	        while (imu.get_status() & pros::c::E_IMU_STATUS_CALIBRATING) {
 		        printf("IMU calibrating... %d\n", iter);
 		        iter += 10;
 		        pros::delay(10);

--- a/v5/api/cpp/imu.rst
+++ b/v5/api/cpp/imu.rst
@@ -514,7 +514,7 @@ This function uses the following values of ``errno`` when an error state is reac
 	        imu_sensor.reset();
 	        int time = pros::millis();
 	        int iter = 0;
-	        while (imu.get_status() & pros::c::E_IMU_STATUS_CALIBRATING) {
+	        while (imu_sensor.get_status() & pros::c::E_IMU_STATUS_CALIBRATING) {
 		        printf("IMU calibrating... %d\n", iter);
 		        iter += 10;
 		        pros::delay(10);


### PR DESCRIPTION
Check out if the `reset() `function's example makes sense. I also think the `get_status()` example needs to be changed but I don't know what would be good example to put in there.