### PR TITLE
Fix set zero position docs

### DIFF
--- a/v5/api/c/motors.rst
+++ b/v5/api/c/motors.rst
@@ -2064,7 +2064,7 @@ Analogous to `pros::Motor::set_zero_position <../cpp/motors.html#set-zero-positi
           }
 
           motor_set_zero_position(1, 80);
-          motor_move_absolute(1, 100, 100); // Moves 20 units forward
+          motor_move_absolute(1, 100, 100); // Moves 80 units forward
           while (!((motor_get_position(1) - 100 < 105) && (motor_get_position(1) - 100 > 95))) {
             delay(2);
           }

--- a/v5/api/c/motors.rst
+++ b/v5/api/c/motors.rst
@@ -2064,7 +2064,7 @@ Analogous to `pros::Motor::set_zero_position <../cpp/motors.html#set-zero-positi
           }
 
           motor_set_zero_position(1, 80);
-          motor_move_absolute(1, 100, 100); // Moves 120 units forward
+          motor_move_absolute(1, 100, 100); // Moves 20 units forward
           while (!((motor_get_position(1) - 100 < 105) && (motor_get_position(1) - 100 > 95))) {
             delay(2);
           }

--- a/v5/api/cpp/motors.rst
+++ b/v5/api/cpp/motors.rst
@@ -2159,7 +2159,7 @@ Analogous to `motor_set_zero_position <../c/motors.html#motor-set-zero-position>
           motor.move_absolute(100, 100); // This does not cause a movement
 
           motor.set_zero_position(80);
-          motor.move_absolute(100, 100); // Moves 120 units forward
+          motor.move_absolute(100, 100); // Moves 80 units forward
         }
 
 ============ ===============================================================


### PR DESCRIPTION
This PR fixes a typo in the C and C++ versions of the `set_zero_position` docs.