### PR TITLE
More visible and more numerous out-of-date Okapi docs warnings.

### DIFF
--- a/v5/okapi/api/chassis/controller/abstract-chassis-controller.rst
+++ b/v5/okapi/api/chassis/controller/abstract-chassis-controller.rst
@@ -2,6 +2,9 @@
 (Abstract) Chassis Controller
 =============================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ChassisController

--- a/v5/okapi/api/chassis/controller/chassis-controller-factory.rst
+++ b/v5/okapi/api/chassis/controller/chassis-controller-factory.rst
@@ -2,6 +2,9 @@
 Chassis Controller Factory
 ==========================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ChassisControllerFactory

--- a/v5/okapi/api/chassis/controller/chassis-controller-integrated.rst
+++ b/v5/okapi/api/chassis/controller/chassis-controller-integrated.rst
@@ -2,6 +2,9 @@
 Chassis Controller Integrated
 =============================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ChassisControllerIntegrated

--- a/v5/okapi/api/chassis/controller/chassis-controller-pid.rst
+++ b/v5/okapi/api/chassis/controller/chassis-controller-pid.rst
@@ -2,6 +2,9 @@
 Chassis Controller PID
 ======================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ChassisControllerPID

--- a/v5/okapi/api/chassis/controller/chassis-scales.rst
+++ b/v5/okapi/api/chassis/controller/chassis-scales.rst
@@ -2,6 +2,9 @@
 Chassis Scales
 ==============
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ChassisScales

--- a/v5/okapi/api/chassis/index.rst
+++ b/v5/okapi/api/chassis/index.rst
@@ -2,8 +2,8 @@
 Chassis API
 ===========
 
-This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
-`here <https://okapilib.github.io/OkapiLib/index.html>`_.
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. toctree::
    :caption: Chassis Controller API

--- a/v5/okapi/api/chassis/model/abstract-chassis-model.rst
+++ b/v5/okapi/api/chassis/model/abstract-chassis-model.rst
@@ -2,6 +2,9 @@
 (Abstract) Chassis Model
 ========================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ChassisModel

--- a/v5/okapi/api/chassis/model/abstract-read-only-chassis-model.rst
+++ b/v5/okapi/api/chassis/model/abstract-read-only-chassis-model.rst
@@ -2,6 +2,9 @@
 (Abstract) Read-Only Chassis Model
 ==================================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ReadOnlyChassisModel

--- a/v5/okapi/api/chassis/model/chassis-model-factory.rst
+++ b/v5/okapi/api/chassis/model/chassis-model-factory.rst
@@ -2,6 +2,9 @@
 Chassis Model Factory
 =====================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ChassisModelFactory

--- a/v5/okapi/api/chassis/model/skid-steer-model.rst
+++ b/v5/okapi/api/chassis/model/skid-steer-model.rst
@@ -2,6 +2,9 @@
 Skid-Steer Model
 ================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::SkidSteerModel

--- a/v5/okapi/api/chassis/model/three-encoder-skid-steer-model.rst
+++ b/v5/okapi/api/chassis/model/three-encoder-skid-steer-model.rst
@@ -2,6 +2,9 @@
 Three Encoder Skid-Steer Model
 ==============================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ThreeEncoderSkidSteerModel

--- a/v5/okapi/api/chassis/model/xdrive-model.rst
+++ b/v5/okapi/api/chassis/model/xdrive-model.rst
@@ -2,6 +2,9 @@
 X-Drive Model
 =============
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::XDriveModel

--- a/v5/okapi/api/control/abstract-closed-loop-controller.rst
+++ b/v5/okapi/api/control/abstract-closed-loop-controller.rst
@@ -2,6 +2,9 @@
 (Abstract) Closed-loop Controller
 =================================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ClosedLoopController

--- a/v5/okapi/api/control/abstract-controller-input.rst
+++ b/v5/okapi/api/control/abstract-controller-input.rst
@@ -2,6 +2,9 @@
 (Abstract) Controller Input
 ===========================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ControllerInput

--- a/v5/okapi/api/control/abstract-controller-output.rst
+++ b/v5/okapi/api/control/abstract-controller-output.rst
@@ -2,6 +2,9 @@
 (Abstract) Controller Output
 ============================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ControllerOutput

--- a/v5/okapi/api/control/async/abstract-async-controller.rst
+++ b/v5/okapi/api/control/async/abstract-async-controller.rst
@@ -2,6 +2,9 @@
 (Abstract) Async Controller
 ===========================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::AsyncControllerArgs

--- a/v5/okapi/api/control/async/abstract-async-position-controller.rst
+++ b/v5/okapi/api/control/async/abstract-async-position-controller.rst
@@ -2,6 +2,9 @@
 (Abstract) Async Position Controller
 ====================================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::AsyncPositionControllerArgs

--- a/v5/okapi/api/control/async/abstract-async-velocity-controller.rst
+++ b/v5/okapi/api/control/async/abstract-async-velocity-controller.rst
@@ -2,6 +2,9 @@
 (Abstract) Async Velocity Controller
 ====================================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::AsyncVelocityControllerArgs

--- a/v5/okapi/api/control/async/async-controller-factory.rst
+++ b/v5/okapi/api/control/async/async-controller-factory.rst
@@ -2,6 +2,9 @@
 Async Controller Factory
 ========================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::AsyncControllerFactory

--- a/v5/okapi/api/control/async/async-linear-motion-profile-controller.rst
+++ b/v5/okapi/api/control/async/async-linear-motion-profile-controller.rst
@@ -2,6 +2,9 @@
 Async Linear Motion Profile Controller
 ======================================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::AsyncLinearMotionProfileController

--- a/v5/okapi/api/control/async/async-motion-profile-controller.rst
+++ b/v5/okapi/api/control/async/async-motion-profile-controller.rst
@@ -2,6 +2,9 @@
 Async Motion Profile Controller
 ===============================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::AsyncMotionProfileController

--- a/v5/okapi/api/control/async/async-pos-integrated-controller.rst
+++ b/v5/okapi/api/control/async/async-pos-integrated-controller.rst
@@ -2,6 +2,9 @@
 Async Pos Integrated Controller
 ===============================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::AsyncPosIntegratedController

--- a/v5/okapi/api/control/async/async-pos-pid-controller.rst
+++ b/v5/okapi/api/control/async/async-pos-pid-controller.rst
@@ -2,6 +2,9 @@
 Async Pos PID Controller
 ========================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::AsyncPosPIDController

--- a/v5/okapi/api/control/async/async-vel-integrated-controller.rst
+++ b/v5/okapi/api/control/async/async-vel-integrated-controller.rst
@@ -2,6 +2,9 @@
 Async Vel Integrated Controller
 ===============================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::AsyncVelIntegratedController

--- a/v5/okapi/api/control/async/async-vel-pid-controller.rst
+++ b/v5/okapi/api/control/async/async-vel-pid-controller.rst
@@ -2,6 +2,9 @@
 Async Vel PID Controller
 ========================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::AsyncVelPIDController

--- a/v5/okapi/api/control/async/async-wrapper.rst
+++ b/v5/okapi/api/control/async/async-wrapper.rst
@@ -2,6 +2,9 @@
 Async Wrapper
 =============
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::AsyncWrapper

--- a/v5/okapi/api/control/index.rst
+++ b/v5/okapi/api/control/index.rst
@@ -2,8 +2,8 @@
 Control API
 ===========
 
-This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
-`here <https://okapilib.github.io/OkapiLib/index.html>`_.
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. toctree::
    :caption: Async Controller API

--- a/v5/okapi/api/control/iterative/abstract-iterative-controller.rst
+++ b/v5/okapi/api/control/iterative/abstract-iterative-controller.rst
@@ -2,6 +2,9 @@
 (Abstract) Iterative Controller
 ===============================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::IterativeController

--- a/v5/okapi/api/control/iterative/abstract-iterative-position-controller.rst
+++ b/v5/okapi/api/control/iterative/abstract-iterative-position-controller.rst
@@ -2,6 +2,9 @@
 (Abstract) Iterative Position Controller
 ========================================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::IterativePositionControllerArgs

--- a/v5/okapi/api/control/iterative/abstract-iterative-velocity-controller.rst
+++ b/v5/okapi/api/control/iterative/abstract-iterative-velocity-controller.rst
@@ -2,6 +2,9 @@
 (Abstract) Iterative Velocity Controller
 ========================================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::IterativeVelocityControllerArgs

--- a/v5/okapi/api/control/iterative/iterative-controller-factory.rst
+++ b/v5/okapi/api/control/iterative/iterative-controller-factory.rst
@@ -2,6 +2,9 @@
 Iterative Controller Factory
 ============================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::IterativeControllerFactory

--- a/v5/okapi/api/control/iterative/iterative-motor-velocity-controller.rst
+++ b/v5/okapi/api/control/iterative/iterative-motor-velocity-controller.rst
@@ -2,6 +2,9 @@
 Iterative Motor Velocity Controller
 ===================================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::IterativeMotorVelocityControllerArgs

--- a/v5/okapi/api/control/iterative/iterative-pos-pid-controller.rst
+++ b/v5/okapi/api/control/iterative/iterative-pos-pid-controller.rst
@@ -2,6 +2,9 @@
 Iterative Pos PID Controller
 ============================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::IterativePosPIDController

--- a/v5/okapi/api/control/iterative/iterative-vel-pid-controller.rst
+++ b/v5/okapi/api/control/iterative/iterative-vel-pid-controller.rst
@@ -2,6 +2,9 @@
 Iterative Vel PID Controller
 ============================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::IterativeVelPIDController

--- a/v5/okapi/api/control/util/controller-runner-factory.rst
+++ b/v5/okapi/api/control/util/controller-runner-factory.rst
@@ -2,6 +2,9 @@
 Controller Runner Factory
 =========================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ControllerRunnerFactory

--- a/v5/okapi/api/control/util/controller-runner.rst
+++ b/v5/okapi/api/control/util/controller-runner.rst
@@ -2,6 +2,9 @@
 Controller Runner
 =================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ControllerRunner

--- a/v5/okapi/api/control/util/pid-tuner-factory.rst
+++ b/v5/okapi/api/control/util/pid-tuner-factory.rst
@@ -2,6 +2,8 @@
 PID Tuner Factory
 =================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:
 

--- a/v5/okapi/api/control/util/pid-tuner.rst
+++ b/v5/okapi/api/control/util/pid-tuner.rst
@@ -2,6 +2,9 @@
 PID Tuner
 =========
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::PIDTuner

--- a/v5/okapi/api/control/util/settled-util-factory.rst
+++ b/v5/okapi/api/control/util/settled-util-factory.rst
@@ -1,6 +1,10 @@
 =======================
 Settled Utility Factory
 =======================
+
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::SettledUtilFactory

--- a/v5/okapi/api/control/util/settled-util.rst
+++ b/v5/okapi/api/control/util/settled-util.rst
@@ -2,6 +2,9 @@
 Settled Utility
 ===============
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::SettledUtil

--- a/v5/okapi/api/device/adi-ultrasonic.rst
+++ b/v5/okapi/api/device/adi-ultrasonic.rst
@@ -2,6 +2,9 @@
 ADI Ultrasonic
 ==============
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ADIUltrasonic

--- a/v5/okapi/api/device/adi-ultrasonic.rst
+++ b/v5/okapi/api/device/adi-ultrasonic.rst
@@ -2,7 +2,7 @@
 ADI Ultrasonic
 ==============
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/button/abstract-button.rst
+++ b/v5/okapi/api/device/button/abstract-button.rst
@@ -2,6 +2,9 @@
 (Abstract) Button
 =================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::Button

--- a/v5/okapi/api/device/button/adi-button.rst
+++ b/v5/okapi/api/device/button/adi-button.rst
@@ -2,6 +2,9 @@
 ADI Button
 ==========
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ADIButton

--- a/v5/okapi/api/device/button/button-base.rst
+++ b/v5/okapi/api/device/button/button-base.rst
@@ -2,6 +2,9 @@
 Button Base
 ===========
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ButtonBase

--- a/v5/okapi/api/device/button/controller-button.rst
+++ b/v5/okapi/api/device/button/controller-button.rst
@@ -2,6 +2,9 @@
 Controller Button
 =================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ControllerButton

--- a/v5/okapi/api/device/button/controller-button.rst
+++ b/v5/okapi/api/device/button/controller-button.rst
@@ -2,7 +2,7 @@
 Controller Button
 =================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/controller.rst
+++ b/v5/okapi/api/device/controller.rst
@@ -2,6 +2,9 @@
 Controller
 ==========
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::Controller

--- a/v5/okapi/api/device/controller.rst
+++ b/v5/okapi/api/device/controller.rst
@@ -2,7 +2,7 @@
 Controller
 ==========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/index.rst
+++ b/v5/okapi/api/device/index.rst
@@ -2,8 +2,8 @@
 Devices API
 ===========
 
-This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
-`here <https://okapilib.github.io/OkapiLib/index.html>`_.
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. toctree::
    :caption: Button API

--- a/v5/okapi/api/device/index.rst
+++ b/v5/okapi/api/device/index.rst
@@ -2,7 +2,7 @@
 Devices API
 ===========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. toctree::

--- a/v5/okapi/api/device/motor/abstract-abstract-motor.rst
+++ b/v5/okapi/api/device/motor/abstract-abstract-motor.rst
@@ -2,6 +2,9 @@
 (Abstract) Abstract Motor
 =========================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::AbstractMotor

--- a/v5/okapi/api/device/motor/abstract-abstract-motor.rst
+++ b/v5/okapi/api/device/motor/abstract-abstract-motor.rst
@@ -2,7 +2,7 @@
 (Abstract) Abstract Motor
 =========================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/motor/adimotor.rst
+++ b/v5/okapi/api/device/motor/adimotor.rst
@@ -2,7 +2,7 @@
 ADI Motor
 =========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/motor/adimotor.rst
+++ b/v5/okapi/api/device/motor/adimotor.rst
@@ -2,6 +2,9 @@
 ADI Motor
 =========
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ADIMotor

--- a/v5/okapi/api/device/motor/motor-group.rst
+++ b/v5/okapi/api/device/motor/motor-group.rst
@@ -2,7 +2,7 @@
 Motor Group
 ===========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/motor/motor-group.rst
+++ b/v5/okapi/api/device/motor/motor-group.rst
@@ -2,6 +2,9 @@
 Motor Group
 ===========
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::MotorGroup

--- a/v5/okapi/api/device/motor/motor.rst
+++ b/v5/okapi/api/device/motor/motor.rst
@@ -2,6 +2,9 @@
 Motor
 =====
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::Motor

--- a/v5/okapi/api/device/motor/motor.rst
+++ b/v5/okapi/api/device/motor/motor.rst
@@ -2,7 +2,7 @@
 Motor
 =====
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/rotarysensor/abstract-continuous-rotary-sensor.rst
+++ b/v5/okapi/api/device/rotarysensor/abstract-continuous-rotary-sensor.rst
@@ -2,7 +2,7 @@
 (Abstract) Continuous Rotary Sensor
 ===================================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/rotarysensor/abstract-continuous-rotary-sensor.rst
+++ b/v5/okapi/api/device/rotarysensor/abstract-continuous-rotary-sensor.rst
@@ -2,6 +2,9 @@
 (Abstract) Continuous Rotary Sensor
 ===================================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ContinuousRotarySensor

--- a/v5/okapi/api/device/rotarysensor/abstract-rotary-sensor.rst
+++ b/v5/okapi/api/device/rotarysensor/abstract-rotary-sensor.rst
@@ -2,6 +2,9 @@
 (Abstract) Rotary Sensor
 ========================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::RotarySensor

--- a/v5/okapi/api/device/rotarysensor/abstract-rotary-sensor.rst
+++ b/v5/okapi/api/device/rotarysensor/abstract-rotary-sensor.rst
@@ -2,7 +2,7 @@
 (Abstract) Rotary Sensor
 ========================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/rotarysensor/adi-encoder.rst
+++ b/v5/okapi/api/device/rotarysensor/adi-encoder.rst
@@ -2,6 +2,9 @@
 ADI Encoder
 ===========
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ADIEncoder

--- a/v5/okapi/api/device/rotarysensor/adi-encoder.rst
+++ b/v5/okapi/api/device/rotarysensor/adi-encoder.rst
@@ -2,7 +2,7 @@
 ADI Encoder
 ===========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/rotarysensor/adi-gyro.rst
+++ b/v5/okapi/api/device/rotarysensor/adi-gyro.rst
@@ -2,7 +2,7 @@
 ADI Gyro
 ========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/rotarysensor/adi-gyro.rst
+++ b/v5/okapi/api/device/rotarysensor/adi-gyro.rst
@@ -2,6 +2,9 @@
 ADI Gyro
 ========
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ADIGyro

--- a/v5/okapi/api/device/rotarysensor/integrated-encoder.rst
+++ b/v5/okapi/api/device/rotarysensor/integrated-encoder.rst
@@ -2,7 +2,7 @@
 Integrated Encoder
 ==================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/rotarysensor/integrated-encoder.rst
+++ b/v5/okapi/api/device/rotarysensor/integrated-encoder.rst
@@ -2,6 +2,9 @@
 Integrated Encoder
 ==================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::IntegratedEncoder

--- a/v5/okapi/api/device/rotarysensor/potentiometer.rst
+++ b/v5/okapi/api/device/rotarysensor/potentiometer.rst
@@ -2,6 +2,9 @@
 Potentiometer
 =============
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::Potentiometer

--- a/v5/okapi/api/device/rotarysensor/potentiometer.rst
+++ b/v5/okapi/api/device/rotarysensor/potentiometer.rst
@@ -2,7 +2,7 @@
 Potentiometer
 =============
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/filters/abstract-filter.rst
+++ b/v5/okapi/api/filters/abstract-filter.rst
@@ -2,6 +2,9 @@
 (Abstract) Filter
 =================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::Filter

--- a/v5/okapi/api/filters/abstract-filter.rst
+++ b/v5/okapi/api/filters/abstract-filter.rst
@@ -2,7 +2,7 @@
 (Abstract) Filter
 =================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/filters/average-filter.rst
+++ b/v5/okapi/api/filters/average-filter.rst
@@ -2,6 +2,9 @@
 Average Filter
 ==============
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::AverageFilter

--- a/v5/okapi/api/filters/average-filter.rst
+++ b/v5/okapi/api/filters/average-filter.rst
@@ -2,7 +2,7 @@
 Average Filter
 ==============
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/filters/composable-filter.rst
+++ b/v5/okapi/api/filters/composable-filter.rst
@@ -2,7 +2,7 @@
 Composable Filter
 =================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/filters/composable-filter.rst
+++ b/v5/okapi/api/filters/composable-filter.rst
@@ -2,6 +2,9 @@
 Composable Filter
 =================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::ComposableFilter

--- a/v5/okapi/api/filters/dema-filter.rst
+++ b/v5/okapi/api/filters/dema-filter.rst
@@ -2,6 +2,9 @@
 DEMA Filter
 ===========
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::DemaFilter

--- a/v5/okapi/api/filters/dema-filter.rst
+++ b/v5/okapi/api/filters/dema-filter.rst
@@ -2,7 +2,7 @@
 DEMA Filter
 ===========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/filters/ema-filter.rst
+++ b/v5/okapi/api/filters/ema-filter.rst
@@ -2,6 +2,9 @@
 EMA Filter
 ==========
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::EmaFilter

--- a/v5/okapi/api/filters/ema-filter.rst
+++ b/v5/okapi/api/filters/ema-filter.rst
@@ -2,7 +2,7 @@
 EMA Filter
 ==========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/filters/filtered-controller-input.rst
+++ b/v5/okapi/api/filters/filtered-controller-input.rst
@@ -2,6 +2,9 @@
 Filtered Controller Input
 =========================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::FilteredControllerInput

--- a/v5/okapi/api/filters/filtered-controller-input.rst
+++ b/v5/okapi/api/filters/filtered-controller-input.rst
@@ -2,7 +2,7 @@
 Filtered Controller Input
 =========================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/filters/index.rst
+++ b/v5/okapi/api/filters/index.rst
@@ -2,6 +2,9 @@
 Filters API
 ===========
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
 `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 

--- a/v5/okapi/api/filters/index.rst
+++ b/v5/okapi/api/filters/index.rst
@@ -2,11 +2,8 @@
 Filters API
 ===========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
-
-This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
-`here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. toctree::
    :maxdepth: 1

--- a/v5/okapi/api/filters/median-filter.rst
+++ b/v5/okapi/api/filters/median-filter.rst
@@ -2,7 +2,7 @@
 Median Filter
 =============
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/filters/median-filter.rst
+++ b/v5/okapi/api/filters/median-filter.rst
@@ -2,6 +2,9 @@
 Median Filter
 =============
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::MedianFilter

--- a/v5/okapi/api/filters/passthrough-filter.rst
+++ b/v5/okapi/api/filters/passthrough-filter.rst
@@ -2,6 +2,9 @@
 Passthrough Filter
 ==================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 Constructor(s)

--- a/v5/okapi/api/filters/passthrough-filter.rst
+++ b/v5/okapi/api/filters/passthrough-filter.rst
@@ -2,7 +2,7 @@
 Passthrough Filter
 ==================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/filters/vel-math-factory.rst
+++ b/v5/okapi/api/filters/vel-math-factory.rst
@@ -2,7 +2,7 @@
 VelMath Factory
 ===============
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/filters/vel-math-factory.rst
+++ b/v5/okapi/api/filters/vel-math-factory.rst
@@ -2,6 +2,9 @@
 VelMath Factory
 ===============
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::VelMathFactory

--- a/v5/okapi/api/filters/vel-math.rst
+++ b/v5/okapi/api/filters/vel-math.rst
@@ -2,7 +2,7 @@
 Velocity Math
 =============
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/filters/vel-math.rst
+++ b/v5/okapi/api/filters/vel-math.rst
@@ -2,6 +2,9 @@
 Velocity Math
 =============
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::VelMathArgs

--- a/v5/okapi/api/index.rst
+++ b/v5/okapi/api/index.rst
@@ -2,8 +2,8 @@
 Legacy OkapiLib API
 ===================
 
-This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
-`here <https://okapilib.github.io/OkapiLib/index.html>`_.
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. toctree::
    :caption: Content

--- a/v5/okapi/api/units/index.rst
+++ b/v5/okapi/api/units/index.rst
@@ -2,7 +2,7 @@
 Units API
 =========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/units/index.rst
+++ b/v5/okapi/api/units/index.rst
@@ -2,8 +2,8 @@
 Units API
 =========
 
-This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
-`here <https://okapilib.github.io/OkapiLib/index.html>`_.
+.. warning:: This documentation is for OkapiLib version 3.x.x, and is inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:
 

--- a/v5/okapi/api/util/abstract-abstract-rate.rst
+++ b/v5/okapi/api/util/abstract-abstract-rate.rst
@@ -2,6 +2,9 @@
 (Abstract) Abstract Rate
 ========================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::AbstractRate

--- a/v5/okapi/api/util/abstract-abstract-timer.rst
+++ b/v5/okapi/api/util/abstract-abstract-timer.rst
@@ -2,6 +2,9 @@
 (Abstract) Abstract Timer
 =========================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::AbstractTimer

--- a/v5/okapi/api/util/index.rst
+++ b/v5/okapi/api/util/index.rst
@@ -2,8 +2,8 @@
 Utility API
 ===========
 
-This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
-`here <https://okapilib.github.io/OkapiLib/index.html>`_.
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. toctree::
    :maxdepth: 1

--- a/v5/okapi/api/util/logging.rst
+++ b/v5/okapi/api/util/logging.rst
@@ -2,6 +2,9 @@
 Logging
 =======
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::Logger

--- a/v5/okapi/api/util/math-util.rst
+++ b/v5/okapi/api/util/math-util.rst
@@ -2,6 +2,9 @@
 Math Utilities
 ==============
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 Math utilities.

--- a/v5/okapi/api/util/rate.rst
+++ b/v5/okapi/api/util/rate.rst
@@ -2,6 +2,9 @@
 Rate
 ====
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::Rate

--- a/v5/okapi/api/util/supplier.rst
+++ b/v5/okapi/api/util/supplier.rst
@@ -2,6 +2,9 @@
 Supplier
 ========
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::Supplier

--- a/v5/okapi/api/util/time-util-factory.rst
+++ b/v5/okapi/api/util/time-util-factory.rst
@@ -2,6 +2,9 @@
 TimeUtil Factory
 ================
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::TimeUtilFactory

--- a/v5/okapi/api/util/time-util.rst
+++ b/v5/okapi/api/util/time-util.rst
@@ -2,6 +2,9 @@
 TimeUtil
 ========
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::TimeUtil

--- a/v5/okapi/api/util/timer.rst
+++ b/v5/okapi/api/util/timer.rst
@@ -2,6 +2,9 @@
 Timer
 =====
 
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
 .. contents:: :local:
 
 okapi::Timer

--- a/v5/okapi/index.rst
+++ b/v5/okapi/index.rst
@@ -15,8 +15,8 @@ floor for teams with all levels of experience. New teams should have an easier t
 robot up and running, and veteran teams should find that OkapiLib doesn't get in the way or place
 any limits on functionality.
 
-This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
-`here <https://okapilib.github.io/OkapiLib/index.html>`_.
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 For tutorials on how to get the most out of OkapiLib, see the **Tutorials** section:
 

--- a/v5/okapi/tutorials/concepts/2dmotionprofiling.rst
+++ b/v5/okapi/tutorials/concepts/2dmotionprofiling.rst
@@ -2,8 +2,8 @@
 2D Motion Profiling
 ===================
 
-This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
-`here <https://okapilib.github.io/OkapiLib/index.html>`_.
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 Motion Profiling is a controls algorithm that defines a movement as a series of
 steps. In one dimension, it defines a motor's position, speed, acceleration, etc.

--- a/v5/okapi/tutorials/concepts/controller-io.rst
+++ b/v5/okapi/tutorials/concepts/controller-io.rst
@@ -2,8 +2,8 @@
 Controller Inputs and Outputs
 =============================
 
-This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
-`here <https://okapilib.github.io/OkapiLib/index.html>`_.
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 Fundamentally, a feedback control system needs both an input and an output.
 In OkapiLib, Iterative Controllers do not require Controller Inputs and Outputs

--- a/v5/okapi/tutorials/concepts/factories.rst
+++ b/v5/okapi/tutorials/concepts/factories.rst
@@ -2,8 +2,8 @@
 Factory Object Creation Pattern
 ===============================
 
-This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
-`here <https://okapilib.github.io/OkapiLib/index.html>`_.
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 OkapiLib uses a pattern of **Factories** to create objects. This means that while you can find constructors
 for any classes you may want to use in ``okapi/api``, creating these classes is best done with

--- a/v5/okapi/tutorials/concepts/filtering.rst
+++ b/v5/okapi/tutorials/concepts/filtering.rst
@@ -2,8 +2,8 @@
 Filtering
 =========
 
-This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
-`here <https://okapilib.github.io/OkapiLib/index.html>`_.
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 OkapiLib makes it easy to use any one of a number of various types of filters on sensors and controllers.
 The specifics of how each filter works and should be initialized will be left to its API reference,

--- a/v5/okapi/tutorials/concepts/iterative-async-controllers.rst
+++ b/v5/okapi/tutorials/concepts/iterative-async-controllers.rst
@@ -2,8 +2,8 @@
 Iterative and Async Controllers
 ===============================
 
-This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
-`here <https://okapilib.github.io/OkapiLib/index.html>`_.
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 OkapiLib provides two main types of feedback controllers, **Iterative Controllers** and **Async Controllers**.
 The two both accomplish the same end goal -- controlling a given system -- but in different manners that makes

--- a/v5/okapi/tutorials/concepts/settled-util.rst
+++ b/v5/okapi/tutorials/concepts/settled-util.rst
@@ -2,8 +2,8 @@
 SettledUtils
 ============
 
-This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
-`here <https://okapilib.github.io/OkapiLib/index.html>`_.
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 One of the most important factors in utilizing feedback controllers is establishing proper
 exit conditions. If a feedback controller decides that it has reached its target and exits too early,

--- a/v5/okapi/tutorials/concepts/smart-pointers.rst
+++ b/v5/okapi/tutorials/concepts/smart-pointers.rst
@@ -2,8 +2,8 @@
 Smart Pointers
 ==============
 
-This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
-`here <https://okapilib.github.io/OkapiLib/index.html>`_.
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 **Smart Pointers** are a C++ concept that extend the functionality of C pointers.
 A knowledge of Smart Pointers is not necessary for simple to intermediate OkapiLib programs,

--- a/v5/okapi/tutorials/index.rst
+++ b/v5/okapi/tutorials/index.rst
@@ -2,8 +2,8 @@
 Legacy OkapiLib Tutorials
 =========================
 
-This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
-`here <https://okapilib.github.io/OkapiLib/index.html>`_.
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 Learning a new coding platform is often a rather daunting task. For this
 reason we prepared some small tutorials with examples on how to interact

--- a/v5/okapi/tutorials/walkthrough/autonomous-movement-async.rst
+++ b/v5/okapi/tutorials/walkthrough/autonomous-movement-async.rst
@@ -2,8 +2,8 @@
 Asynchronous Autonomous Movement
 ================================
 
-This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
-`here <https://okapilib.github.io/OkapiLib/index.html>`_.
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. note:: This tutorial covers asynchronous movement (multiple subsystems operating at a time).
           For a more basic tutorial on sequential movements, see `Moving Autonomously <./autonomous-movement-basic.html>`_.

--- a/v5/okapi/tutorials/walkthrough/autonomous-movement-basic.rst
+++ b/v5/okapi/tutorials/walkthrough/autonomous-movement-basic.rst
@@ -2,8 +2,8 @@
 Moving Autonomously
 ===================
 
-This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
-`here <https://okapilib.github.io/OkapiLib/index.html>`_.
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. note:: This tutorial covers only sequential movement (only one subsystem operating at a time).
           For a tutorial on asynchronous movements, see `Asynchronous Autonomous Movement <./autonomous-movement-async.html>`_.

--- a/v5/okapi/tutorials/walkthrough/clawbot.rst
+++ b/v5/okapi/tutorials/walkthrough/clawbot.rst
@@ -2,8 +2,8 @@
 Programming the Clawbot
 =======================
 
-This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
-`here <https://okapilib.github.io/OkapiLib/index.html>`_.
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 Objective:
 ==========

--- a/v5/okapi/tutorials/walkthrough/getting-started.rst
+++ b/v5/okapi/tutorials/walkthrough/getting-started.rst
@@ -2,9 +2,8 @@
 Getting Started with OkapiLib
 =============================
 
-This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
-`here <https://okapilib.github.io/OkapiLib/index.html>`_.
-
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 Introduction
 ============
 

--- a/v5/okapi/tutorials/walkthrough/lift-movement.rst
+++ b/v5/okapi/tutorials/walkthrough/lift-movement.rst
@@ -2,8 +2,8 @@
 Lift Movement
 =============
 
-This documentation is for OkapiLib version 3.x.x. Documentation for the latest version can be found
-`here <https://okapilib.github.io/OkapiLib/index.html>`_.
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 In VEX, a large majority of games require the use of a lift, and it serves as a great example for controlling
 non-chassis systems.


### PR DESCRIPTION
Added more warnings indicating that the up to date docs have been moved and the contents of each Okapi page might be inaccurate. Also made pre-existing warnings more visible using the
actual warning paragraph format.