### PR TITLE
Update to Warning messages

### DIFF
--- a/v5/okapi/api/chassis/controller/abstract-chassis-controller.rst
+++ b/v5/okapi/api/chassis/controller/abstract-chassis-controller.rst
@@ -2,7 +2,7 @@
 (Abstract) Chassis Controller
 =============================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/chassis/controller/chassis-controller-factory.rst
+++ b/v5/okapi/api/chassis/controller/chassis-controller-factory.rst
@@ -2,7 +2,7 @@
 Chassis Controller Factory
 ==========================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/chassis/controller/chassis-controller-integrated.rst
+++ b/v5/okapi/api/chassis/controller/chassis-controller-integrated.rst
@@ -2,7 +2,7 @@
 Chassis Controller Integrated
 =============================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/chassis/controller/chassis-controller-pid.rst
+++ b/v5/okapi/api/chassis/controller/chassis-controller-pid.rst
@@ -2,7 +2,7 @@
 Chassis Controller PID
 ======================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/chassis/controller/chassis-scales.rst
+++ b/v5/okapi/api/chassis/controller/chassis-scales.rst
@@ -2,7 +2,7 @@
 Chassis Scales
 ==============
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/chassis/index.rst
+++ b/v5/okapi/api/chassis/index.rst
@@ -2,7 +2,7 @@
 Chassis API
 ===========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. toctree::

--- a/v5/okapi/api/chassis/model/abstract-chassis-model.rst
+++ b/v5/okapi/api/chassis/model/abstract-chassis-model.rst
@@ -2,7 +2,7 @@
 (Abstract) Chassis Model
 ========================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/chassis/model/abstract-read-only-chassis-model.rst
+++ b/v5/okapi/api/chassis/model/abstract-read-only-chassis-model.rst
@@ -2,7 +2,7 @@
 (Abstract) Read-Only Chassis Model
 ==================================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/chassis/model/chassis-model-factory.rst
+++ b/v5/okapi/api/chassis/model/chassis-model-factory.rst
@@ -2,7 +2,7 @@
 Chassis Model Factory
 =====================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/chassis/model/skid-steer-model.rst
+++ b/v5/okapi/api/chassis/model/skid-steer-model.rst
@@ -2,7 +2,7 @@
 Skid-Steer Model
 ================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/chassis/model/three-encoder-skid-steer-model.rst
+++ b/v5/okapi/api/chassis/model/three-encoder-skid-steer-model.rst
@@ -2,7 +2,7 @@
 Three Encoder Skid-Steer Model
 ==============================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/chassis/model/xdrive-model.rst
+++ b/v5/okapi/api/chassis/model/xdrive-model.rst
@@ -2,7 +2,7 @@
 X-Drive Model
 =============
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/abstract-closed-loop-controller.rst
+++ b/v5/okapi/api/control/abstract-closed-loop-controller.rst
@@ -2,7 +2,7 @@
 (Abstract) Closed-loop Controller
 =================================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/abstract-controller-input.rst
+++ b/v5/okapi/api/control/abstract-controller-input.rst
@@ -2,7 +2,7 @@
 (Abstract) Controller Input
 ===========================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/abstract-controller-output.rst
+++ b/v5/okapi/api/control/abstract-controller-output.rst
@@ -2,7 +2,7 @@
 (Abstract) Controller Output
 ============================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/async/abstract-async-controller.rst
+++ b/v5/okapi/api/control/async/abstract-async-controller.rst
@@ -2,7 +2,7 @@
 (Abstract) Async Controller
 ===========================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/async/abstract-async-position-controller.rst
+++ b/v5/okapi/api/control/async/abstract-async-position-controller.rst
@@ -2,7 +2,7 @@
 (Abstract) Async Position Controller
 ====================================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/async/abstract-async-velocity-controller.rst
+++ b/v5/okapi/api/control/async/abstract-async-velocity-controller.rst
@@ -2,7 +2,7 @@
 (Abstract) Async Velocity Controller
 ====================================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/async/async-controller-factory.rst
+++ b/v5/okapi/api/control/async/async-controller-factory.rst
@@ -2,7 +2,7 @@
 Async Controller Factory
 ========================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/async/async-linear-motion-profile-controller.rst
+++ b/v5/okapi/api/control/async/async-linear-motion-profile-controller.rst
@@ -2,7 +2,7 @@
 Async Linear Motion Profile Controller
 ======================================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/async/async-motion-profile-controller.rst
+++ b/v5/okapi/api/control/async/async-motion-profile-controller.rst
@@ -2,7 +2,7 @@
 Async Motion Profile Controller
 ===============================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/async/async-pos-integrated-controller.rst
+++ b/v5/okapi/api/control/async/async-pos-integrated-controller.rst
@@ -2,7 +2,7 @@
 Async Pos Integrated Controller
 ===============================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/async/async-pos-pid-controller.rst
+++ b/v5/okapi/api/control/async/async-pos-pid-controller.rst
@@ -2,7 +2,7 @@
 Async Pos PID Controller
 ========================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/async/async-vel-integrated-controller.rst
+++ b/v5/okapi/api/control/async/async-vel-integrated-controller.rst
@@ -2,7 +2,7 @@
 Async Vel Integrated Controller
 ===============================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/async/async-vel-pid-controller.rst
+++ b/v5/okapi/api/control/async/async-vel-pid-controller.rst
@@ -2,7 +2,7 @@
 Async Vel PID Controller
 ========================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/async/async-wrapper.rst
+++ b/v5/okapi/api/control/async/async-wrapper.rst
@@ -2,7 +2,7 @@
 Async Wrapper
 =============
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/index.rst
+++ b/v5/okapi/api/control/index.rst
@@ -2,7 +2,7 @@
 Control API
 ===========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. toctree::

--- a/v5/okapi/api/control/iterative/abstract-iterative-controller.rst
+++ b/v5/okapi/api/control/iterative/abstract-iterative-controller.rst
@@ -2,7 +2,7 @@
 (Abstract) Iterative Controller
 ===============================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/iterative/abstract-iterative-position-controller.rst
+++ b/v5/okapi/api/control/iterative/abstract-iterative-position-controller.rst
@@ -2,7 +2,7 @@
 (Abstract) Iterative Position Controller
 ========================================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/iterative/abstract-iterative-velocity-controller.rst
+++ b/v5/okapi/api/control/iterative/abstract-iterative-velocity-controller.rst
@@ -2,7 +2,7 @@
 (Abstract) Iterative Velocity Controller
 ========================================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/iterative/iterative-controller-factory.rst
+++ b/v5/okapi/api/control/iterative/iterative-controller-factory.rst
@@ -2,7 +2,7 @@
 Iterative Controller Factory
 ============================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/iterative/iterative-motor-velocity-controller.rst
+++ b/v5/okapi/api/control/iterative/iterative-motor-velocity-controller.rst
@@ -2,7 +2,7 @@
 Iterative Motor Velocity Controller
 ===================================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/iterative/iterative-pos-pid-controller.rst
+++ b/v5/okapi/api/control/iterative/iterative-pos-pid-controller.rst
@@ -2,7 +2,7 @@
 Iterative Pos PID Controller
 ============================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/iterative/iterative-vel-pid-controller.rst
+++ b/v5/okapi/api/control/iterative/iterative-vel-pid-controller.rst
@@ -2,7 +2,7 @@
 Iterative Vel PID Controller
 ============================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/util/controller-runner-factory.rst
+++ b/v5/okapi/api/control/util/controller-runner-factory.rst
@@ -2,7 +2,7 @@
 Controller Runner Factory
 =========================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/util/controller-runner.rst
+++ b/v5/okapi/api/control/util/controller-runner.rst
@@ -2,7 +2,7 @@
 Controller Runner
 =================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/util/pid-tuner-factory.rst
+++ b/v5/okapi/api/control/util/pid-tuner-factory.rst
@@ -2,7 +2,7 @@
 PID Tuner Factory
 =================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/util/pid-tuner.rst
+++ b/v5/okapi/api/control/util/pid-tuner.rst
@@ -2,7 +2,7 @@
 PID Tuner
 =========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/util/settled-util-factory.rst
+++ b/v5/okapi/api/control/util/settled-util-factory.rst
@@ -2,7 +2,7 @@
 Settled Utility Factory
 =======================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/control/util/settled-util.rst
+++ b/v5/okapi/api/control/util/settled-util.rst
@@ -2,7 +2,7 @@
 Settled Utility
 ===============
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/adi-ultrasonic.rst
+++ b/v5/okapi/api/device/adi-ultrasonic.rst
@@ -2,7 +2,7 @@
 ADI Ultrasonic
 ==============
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/button/abstract-button.rst
+++ b/v5/okapi/api/device/button/abstract-button.rst
@@ -2,7 +2,7 @@
 (Abstract) Button
 =================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/button/adi-button.rst
+++ b/v5/okapi/api/device/button/adi-button.rst
@@ -2,7 +2,7 @@
 ADI Button
 ==========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/button/button-base.rst
+++ b/v5/okapi/api/device/button/button-base.rst
@@ -2,7 +2,7 @@
 Button Base
 ===========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/button/controller-button.rst
+++ b/v5/okapi/api/device/button/controller-button.rst
@@ -2,7 +2,7 @@
 Controller Button
 =================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/controller.rst
+++ b/v5/okapi/api/device/controller.rst
@@ -2,7 +2,7 @@
 Controller
 ==========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/index.rst
+++ b/v5/okapi/api/device/index.rst
@@ -2,7 +2,7 @@
 Devices API
 ===========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. toctree::

--- a/v5/okapi/api/device/motor/abstract-abstract-motor.rst
+++ b/v5/okapi/api/device/motor/abstract-abstract-motor.rst
@@ -2,7 +2,7 @@
 (Abstract) Abstract Motor
 =========================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/motor/adimotor.rst
+++ b/v5/okapi/api/device/motor/adimotor.rst
@@ -2,7 +2,7 @@
 ADI Motor
 =========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/motor/motor-group.rst
+++ b/v5/okapi/api/device/motor/motor-group.rst
@@ -2,7 +2,7 @@
 Motor Group
 ===========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/motor/motor.rst
+++ b/v5/okapi/api/device/motor/motor.rst
@@ -2,7 +2,7 @@
 Motor
 =====
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/rotarysensor/abstract-continuous-rotary-sensor.rst
+++ b/v5/okapi/api/device/rotarysensor/abstract-continuous-rotary-sensor.rst
@@ -2,7 +2,7 @@
 (Abstract) Continuous Rotary Sensor
 ===================================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/rotarysensor/abstract-rotary-sensor.rst
+++ b/v5/okapi/api/device/rotarysensor/abstract-rotary-sensor.rst
@@ -2,7 +2,7 @@
 (Abstract) Rotary Sensor
 ========================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/rotarysensor/adi-encoder.rst
+++ b/v5/okapi/api/device/rotarysensor/adi-encoder.rst
@@ -2,7 +2,7 @@
 ADI Encoder
 ===========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/rotarysensor/adi-gyro.rst
+++ b/v5/okapi/api/device/rotarysensor/adi-gyro.rst
@@ -2,7 +2,7 @@
 ADI Gyro
 ========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/rotarysensor/integrated-encoder.rst
+++ b/v5/okapi/api/device/rotarysensor/integrated-encoder.rst
@@ -2,7 +2,7 @@
 Integrated Encoder
 ==================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/device/rotarysensor/potentiometer.rst
+++ b/v5/okapi/api/device/rotarysensor/potentiometer.rst
@@ -2,7 +2,7 @@
 Potentiometer
 =============
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/filters/abstract-filter.rst
+++ b/v5/okapi/api/filters/abstract-filter.rst
@@ -2,7 +2,7 @@
 (Abstract) Filter
 =================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/filters/average-filter.rst
+++ b/v5/okapi/api/filters/average-filter.rst
@@ -2,7 +2,7 @@
 Average Filter
 ==============
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/filters/composable-filter.rst
+++ b/v5/okapi/api/filters/composable-filter.rst
@@ -2,7 +2,7 @@
 Composable Filter
 =================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/filters/dema-filter.rst
+++ b/v5/okapi/api/filters/dema-filter.rst
@@ -2,7 +2,7 @@
 DEMA Filter
 ===========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/filters/ema-filter.rst
+++ b/v5/okapi/api/filters/ema-filter.rst
@@ -2,7 +2,7 @@
 EMA Filter
 ==========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/filters/filtered-controller-input.rst
+++ b/v5/okapi/api/filters/filtered-controller-input.rst
@@ -2,7 +2,7 @@
 Filtered Controller Input
 =========================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/filters/index.rst
+++ b/v5/okapi/api/filters/index.rst
@@ -2,7 +2,7 @@
 Filters API
 ===========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. toctree::

--- a/v5/okapi/api/filters/median-filter.rst
+++ b/v5/okapi/api/filters/median-filter.rst
@@ -2,7 +2,7 @@
 Median Filter
 =============
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/filters/passthrough-filter.rst
+++ b/v5/okapi/api/filters/passthrough-filter.rst
@@ -2,7 +2,7 @@
 Passthrough Filter
 ==================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/filters/vel-math-factory.rst
+++ b/v5/okapi/api/filters/vel-math-factory.rst
@@ -2,7 +2,7 @@
 VelMath Factory
 ===============
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/filters/vel-math.rst
+++ b/v5/okapi/api/filters/vel-math.rst
@@ -2,7 +2,7 @@
 Velocity Math
 =============
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/index.rst
+++ b/v5/okapi/api/index.rst
@@ -2,7 +2,7 @@
 Legacy OkapiLib API
 ===================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. toctree::

--- a/v5/okapi/api/units/index.rst
+++ b/v5/okapi/api/units/index.rst
@@ -2,7 +2,7 @@
 Units API
 =========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/util/abstract-abstract-rate.rst
+++ b/v5/okapi/api/util/abstract-abstract-rate.rst
@@ -2,7 +2,7 @@
 (Abstract) Abstract Rate
 ========================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/util/abstract-abstract-timer.rst
+++ b/v5/okapi/api/util/abstract-abstract-timer.rst
@@ -2,7 +2,7 @@
 (Abstract) Abstract Timer
 =========================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/util/index.rst
+++ b/v5/okapi/api/util/index.rst
@@ -2,7 +2,7 @@
 Utility API
 ===========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. toctree::

--- a/v5/okapi/api/util/logging.rst
+++ b/v5/okapi/api/util/logging.rst
@@ -2,7 +2,7 @@
 Logging
 =======
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/util/math-util.rst
+++ b/v5/okapi/api/util/math-util.rst
@@ -2,7 +2,7 @@
 Math Utilities
 ==============
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/util/rate.rst
+++ b/v5/okapi/api/util/rate.rst
@@ -2,7 +2,7 @@
 Rate
 ====
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/util/supplier.rst
+++ b/v5/okapi/api/util/supplier.rst
@@ -2,7 +2,7 @@
 Supplier
 ========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/util/time-util-factory.rst
+++ b/v5/okapi/api/util/time-util-factory.rst
@@ -2,7 +2,7 @@
 TimeUtil Factory
 ================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/util/time-util.rst
+++ b/v5/okapi/api/util/time-util.rst
@@ -2,7 +2,7 @@
 TimeUtil
 ========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/api/util/timer.rst
+++ b/v5/okapi/api/util/timer.rst
@@ -2,7 +2,7 @@
 Timer
 =====
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. contents:: :local:

--- a/v5/okapi/index.rst
+++ b/v5/okapi/index.rst
@@ -15,7 +15,7 @@ floor for teams with all levels of experience. New teams should have an easier t
 robot up and running, and veteran teams should find that OkapiLib doesn't get in the way or place
 any limits on functionality.
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 For tutorials on how to get the most out of OkapiLib, see the **Tutorials** section:

--- a/v5/okapi/tutorials/concepts/2dmotionprofiling.rst
+++ b/v5/okapi/tutorials/concepts/2dmotionprofiling.rst
@@ -2,7 +2,7 @@
 2D Motion Profiling
 ===================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 Motion Profiling is a controls algorithm that defines a movement as a series of

--- a/v5/okapi/tutorials/concepts/2dmotionprofiling.rst
+++ b/v5/okapi/tutorials/concepts/2dmotionprofiling.rst
@@ -5,6 +5,9 @@
 .. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
+.. note:: An updated version of this tutorial for Okapi 4.x.x and above can be found 
+         `here <https://okapilib.github.io/OkapiLib/md_docs_tutorials_concepts_twodmotionprofiling.html>`_.
+
 Motion Profiling is a controls algorithm that defines a movement as a series of
 steps. In one dimension, it defines a motor's position, speed, acceleration, etc.
 at every timestep during the movement. In two dimensions, it defines your robot's

--- a/v5/okapi/tutorials/concepts/controller-io.rst
+++ b/v5/okapi/tutorials/concepts/controller-io.rst
@@ -2,7 +2,7 @@
 Controller Inputs and Outputs
 =============================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 Fundamentally, a feedback control system needs both an input and an output.

--- a/v5/okapi/tutorials/concepts/controller-io.rst
+++ b/v5/okapi/tutorials/concepts/controller-io.rst
@@ -5,6 +5,9 @@ Controller Inputs and Outputs
 .. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
+.. note:: An updated version of this tutorial for Okapi 4.x.x and above can be found 
+         `here <https://okapilib.github.io/OkapiLib/md_docs_tutorials_concepts_controller-io.html>`_.
+
 Fundamentally, a feedback control system needs both an input and an output.
 In OkapiLib, Iterative Controllers do not require Controller Inputs and Outputs
 to be passed into the constructor like Async Controllers do, but they are still

--- a/v5/okapi/tutorials/concepts/factories.rst
+++ b/v5/okapi/tutorials/concepts/factories.rst
@@ -3,7 +3,7 @@ Factory Object Creation Pattern
 ===============================
 
 .. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
-         `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+         `here <https://okapilib.github.io/OkapiLib/index.html>`_. 
 
 OkapiLib uses a pattern of **Factories** to create objects. This means that while you can find constructors
 for any classes you may want to use in ``okapi/api``, creating these classes is best done with

--- a/v5/okapi/tutorials/concepts/factories.rst
+++ b/v5/okapi/tutorials/concepts/factories.rst
@@ -2,7 +2,7 @@
 Factory Object Creation Pattern
 ===============================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 OkapiLib uses a pattern of **Factories** to create objects. This means that while you can find constructors

--- a/v5/okapi/tutorials/concepts/filtering.rst
+++ b/v5/okapi/tutorials/concepts/filtering.rst
@@ -2,7 +2,7 @@
 Filtering
 =========
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 OkapiLib makes it easy to use any one of a number of various types of filters on sensors and controllers.

--- a/v5/okapi/tutorials/concepts/filtering.rst
+++ b/v5/okapi/tutorials/concepts/filtering.rst
@@ -5,6 +5,9 @@ Filtering
 .. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
+.. note:: An updated version of this tutorial for Okapi 4.x.x and above can be found 
+         `here <https://okapilib.github.io/OkapiLib/md_docs_tutorials_concepts_filtering.html>`_.
+
 OkapiLib makes it easy to use any one of a number of various types of filters on sensors and controllers.
 The specifics of how each filter works and should be initialized will be left to its API reference,
 but this guide will help provide the general knowledge necessary to make the most out of OkapiLib's

--- a/v5/okapi/tutorials/concepts/iterative-async-controllers.rst
+++ b/v5/okapi/tutorials/concepts/iterative-async-controllers.rst
@@ -2,7 +2,7 @@
 Iterative and Async Controllers
 ===============================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 OkapiLib provides two main types of feedback controllers, **Iterative Controllers** and **Async Controllers**.

--- a/v5/okapi/tutorials/concepts/iterative-async-controllers.rst
+++ b/v5/okapi/tutorials/concepts/iterative-async-controllers.rst
@@ -5,6 +5,9 @@ Iterative and Async Controllers
 .. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
+.. note:: An updated version of this tutorial for Okapi 4.x.x and above can be found 
+         `here <https://okapilib.github.io/OkapiLib/md_docs_tutorials_concepts_iterative-async-controllers.html>`_.
+
 OkapiLib provides two main types of feedback controllers, **Iterative Controllers** and **Async Controllers**.
 The two both accomplish the same end goal -- controlling a given system -- but in different manners that makes
 them tailored for different applications. You can achieve the same response from a system with either option,

--- a/v5/okapi/tutorials/concepts/settled-util.rst
+++ b/v5/okapi/tutorials/concepts/settled-util.rst
@@ -2,7 +2,7 @@
 SettledUtils
 ============
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 One of the most important factors in utilizing feedback controllers is establishing proper

--- a/v5/okapi/tutorials/concepts/settled-util.rst
+++ b/v5/okapi/tutorials/concepts/settled-util.rst
@@ -5,6 +5,9 @@ SettledUtils
 .. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
+.. note:: An updated version of this tutorial for Okapi 4.x.x and above can be found 
+         `here <https://okapilib.github.io/OkapiLib/md_docs_tutorials_concepts_settled-util.html>`_.
+
 One of the most important factors in utilizing feedback controllers is establishing proper
 exit conditions. If a feedback controller decides that it has reached its target and exits too early,
 then the target will never be met. Alternatively, if the controller takes too long to realize that it's

--- a/v5/okapi/tutorials/concepts/smart-pointers.rst
+++ b/v5/okapi/tutorials/concepts/smart-pointers.rst
@@ -2,7 +2,7 @@
 Smart Pointers
 ==============
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 **Smart Pointers** are a C++ concept that extend the functionality of C pointers.

--- a/v5/okapi/tutorials/index.rst
+++ b/v5/okapi/tutorials/index.rst
@@ -5,6 +5,9 @@ Legacy OkapiLib Tutorials
 .. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
+.. note:: The latest OkapiLib tutorials can be found 
+         `here <https://okapilib.github.io/OkapiLib/md_docs_tutorials_index.html>`_.     
+
 Learning a new coding platform is often a rather daunting task. For this
 reason we prepared some small tutorials with examples on how to interact
 with OkapiLib on your VEX V5 system.

--- a/v5/okapi/tutorials/index.rst
+++ b/v5/okapi/tutorials/index.rst
@@ -2,7 +2,7 @@
 Legacy OkapiLib Tutorials
 =========================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 Learning a new coding platform is often a rather daunting task. For this

--- a/v5/okapi/tutorials/walkthrough/autonomous-movement-async.rst
+++ b/v5/okapi/tutorials/walkthrough/autonomous-movement-async.rst
@@ -2,7 +2,7 @@
 Asynchronous Autonomous Movement
 ================================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. note:: This tutorial covers asynchronous movement (multiple subsystems operating at a time).

--- a/v5/okapi/tutorials/walkthrough/autonomous-movement-async.rst
+++ b/v5/okapi/tutorials/walkthrough/autonomous-movement-async.rst
@@ -5,6 +5,9 @@ Asynchronous Autonomous Movement
 .. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
+.. note:: An updated version of this tutorial for Okapi 4.x.x and above can be found 
+         `here <https://okapilib.github.io/OkapiLib/md_docs_tutorials_walkthrough_asyncAutonomousMovement.html>`_.
+
 .. note:: This tutorial covers asynchronous movement (multiple subsystems operating at a time).
           For a more basic tutorial on sequential movements, see `Moving Autonomously <./autonomous-movement-basic.html>`_.
 

--- a/v5/okapi/tutorials/walkthrough/autonomous-movement-basic.rst
+++ b/v5/okapi/tutorials/walkthrough/autonomous-movement-basic.rst
@@ -5,6 +5,9 @@ Moving Autonomously
 .. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
+.. note:: An updated version of this tutorial for Okapi 4.x.x and above can be found 
+         `here <https://okapilib.github.io/OkapiLib/md_docs_tutorials_walkthrough_basicAutonomousMovement.html>`_.
+
 .. note:: This tutorial covers only sequential movement (only one subsystem operating at a time).
           For a tutorial on asynchronous movements, see `Asynchronous Autonomous Movement <./autonomous-movement-async.html>`_.
 

--- a/v5/okapi/tutorials/walkthrough/autonomous-movement-basic.rst
+++ b/v5/okapi/tutorials/walkthrough/autonomous-movement-basic.rst
@@ -2,7 +2,7 @@
 Moving Autonomously
 ===================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. note:: This tutorial covers only sequential movement (only one subsystem operating at a time).

--- a/v5/okapi/tutorials/walkthrough/clawbot.rst
+++ b/v5/okapi/tutorials/walkthrough/clawbot.rst
@@ -2,8 +2,11 @@
 Programming the Clawbot
 =======================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
+.. note:: An updated version of the clawbot tutorial for Okapi 4.x.x and above can be found
+         `here <https://okapilib.github.io/OkapiLib/md_docs_tutorials_walkthrough_clawbot.html>`_.
 
 Objective:
 ==========

--- a/v5/okapi/tutorials/walkthrough/getting-started.rst
+++ b/v5/okapi/tutorials/walkthrough/getting-started.rst
@@ -2,7 +2,7 @@
 Getting Started with OkapiLib
 =============================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 .. note:: The latest version of this tutorial can be found 

--- a/v5/okapi/tutorials/walkthrough/getting-started.rst
+++ b/v5/okapi/tutorials/walkthrough/getting-started.rst
@@ -2,8 +2,11 @@
 Getting Started with OkapiLib
 =============================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
+
+.. note:: The latest version of this tutorial can be found 
+         `here <https://okapilib.github.io/OkapiLib/md_docs_tutorials_index.html>`_.         
 Introduction
 ============
 

--- a/v5/okapi/tutorials/walkthrough/getting-started.rst
+++ b/v5/okapi/tutorials/walkthrough/getting-started.rst
@@ -2,7 +2,7 @@
 Getting Started with OkapiLib
 =============================
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 Introduction
 ============

--- a/v5/okapi/tutorials/walkthrough/lift-movement.rst
+++ b/v5/okapi/tutorials/walkthrough/lift-movement.rst
@@ -5,6 +5,9 @@ Lift Movement
 .. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
+.. note:: The latest version of this tutorial can be found 
+         `here <https://okapilib.github.io/OkapiLib/md_docs_tutorials_walkthrough_liftMovement.html>`_. 
+
 In VEX, a large majority of games require the use of a lift, and it serves as a great example for controlling
 non-chassis systems.
 

--- a/v5/okapi/tutorials/walkthrough/lift-movement.rst
+++ b/v5/okapi/tutorials/walkthrough/lift-movement.rst
@@ -2,7 +2,7 @@
 Lift Movement
 =============
 
-.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.X.X and above. Documentation for the latest version can be found
+.. warning:: This documentation is for OkapiLib version 3.x.x, and might be inaccurate for versions 4.x.x and above. Documentation for the latest version can be found
          `here <https://okapilib.github.io/OkapiLib/index.html>`_.
 
 In VEX, a large majority of games require the use of a lift, and it serves as a great example for controlling


### PR DESCRIPTION
Changed the 4.X.X. to lowercase 4.x.x in each warning at the top of each okapi document.

Added notes to applicable tutorials with links to the new docs that have equivalent ones. 
("The latest version of this tutorial can be found here.")