### PR TITLE
Contact Us Link Fix

### DIFF
--- a/v5/contact.rst
+++ b/v5/contact.rst
@@ -3,7 +3,7 @@ Getting Help
 
 Having an issue using PROS? You can get help in several ways:
 
-* Posting on the `VEX Forum <https://www.vexforum.com/c/programming-support/pros-support/64>`_ (best for Q&A)
+* Posting on the `VEX Forum <https://www.vexforum.com/c/programming-support/pros-support>`_ (best for Q&A)
 * Joining us on `Slack <https://join.slack.com/t/pros-development/shared_invite/enQtMzIyNzA2MTU2MDgwLWUwYzRhODRkYjU5ZmM5OTFhOWQxNjc4MzQ1OTc0MjU0MGFiMDdlMTQ3YTdhNDc2ZDU3NjcyZjM4MDgwNGMzOGE>`_ (best for debugging an issue with the PROS Environment)
 * Open an issue on GitHub (best for reporting an issue you've discovered):
 

--- a/v5/contact.rst
+++ b/v5/contact.rst
@@ -3,7 +3,7 @@ Getting Help
 
 Having an issue using PROS? You can get help in several ways:
 
-* Posting on the `VEX Forum <https://www.vexforum.com/c/edr-technical-support/pros-support>`_ (best for Q&A)
+* Posting on the `VEX Forum <https://www.vexforum.com/c/programming-support/pros-support/64>`_ (best for Q&A)
 * Joining us on `Slack <https://join.slack.com/t/pros-development/shared_invite/enQtMzIyNzA2MTU2MDgwLWUwYzRhODRkYjU5ZmM5OTFhOWQxNjc4MzQ1OTc0MjU0MGFiMDdlMTQ3YTdhNDc2ZDU3NjcyZjM4MDgwNGMzOGE>`_ (best for debugging an issue with the PROS Environment)
 * Open an issue on GitHub (best for reporting an issue you've discovered):
 


### PR DESCRIPTION
Fixed link leading to VF's PROS section, located on this page: https://pros.cs.purdue.edu/v5/contact.html

Replaced first link with updated link that works with the new VEXForum update (that happened about a year ago)