### PR TITLE
Fix missing </a> in StickerMule link

### DIFF
--- a/home/_templates/index.html
+++ b/home/_templates/index.html
@@ -205,6 +205,7 @@
               </div>
                <a href="http://www.stickermule.com/supports/pros" target="_blank">
                 <img src="_static/img/mule.png" width="100%" height="50%">
+               </a>
             </div>
             <div class="big_title_txt_separ background_color"></div>
          </div>


### PR DESCRIPTION
Currently, the image link to StickerMule does not have a closing </a> tag, so everything below it (including the PROS logo in the footer and the license info, up to the link in the copyright) links to StickerMule.

This PR adds a </a> tag so that the rest of the page behaves normally.