### PR TITLE
Rotation/Optical Page Fixes

### DIFF
--- a/v5/api/c/optical.rst
+++ b/v5/api/c/optical.rst
@@ -72,7 +72,7 @@ Analogous to `pros::Optical::get <../cpp/Optical.html#set_reversed>`_.
       .. highlight:: c
       ::
 
-    double optical_get_saturation(uint8_t port);
+        double optical_get_saturation(uint8_t port);
 
    .. tab :: Example
       .. highlight:: c
@@ -116,7 +116,7 @@ Analogous to `pros::Optical::get <../cpp/Optical.html#get_reversed>`_.
       .. highlight:: c
       ::
 
-    double optical_get_brightness(uint8_t port);
+        double optical_get_brightness(uint8_t port);
 
    .. tab :: Example
       .. highlight:: c
@@ -159,7 +159,7 @@ Analogous to `pros::Optical::get <../cpp/Optical.html#set_position>`_.
       .. highlight:: c
       ::
 
-    int32_t optical_get_proximity(uint8_t port);
+        int32_t optical_get_proximity(uint8_t port);
 
    .. tab :: Example
       .. highlight:: c
@@ -202,7 +202,7 @@ Analogous to `pros::Optical::get <../cpp/optical.html#get_position>`_.
       .. highlight:: c
       ::
 
-    int32_t optical_set_led_pwm(uint8_t port, uint8_t value);
+        int32_t optical_set_led_pwm(uint8_t port, uint8_t value);
 
    .. tab :: Example
       .. highlight:: c
@@ -245,7 +245,7 @@ Analogous to `pros::Optical::get <../cpp/optical.html#get_angle>`_.
       .. highlight:: c
       ::
 
-    int32_t optical_get_led_pwm(uint8_t port);
+        int32_t optical_get_led_pwm(uint8_t port);
 
    .. tab :: Example
       .. highlight:: c
@@ -287,7 +287,7 @@ Analogous to `pros::Optical::get <../cpp/optical.html#get_velocity>`_.
       .. highlight:: c
       ::
 
-    optical_rgb_s_t optical_get_rgb(uint8_t port);
+        optical_rgb_s_t optical_get_rgb(uint8_t port);
 
    .. tab :: Example
       .. highlight:: c
@@ -334,7 +334,7 @@ Analogous to `pros::Optical::get <../cpp/optical.html#get_velocity>`_.
       .. highlight:: c
       ::
 
-    optical_raw_s_t optical_get_raw(uint8_t port);
+       optical_raw_s_t optical_get_raw(uint8_t port);
 
    .. tab :: Example
       .. highlight:: c
@@ -383,7 +383,7 @@ Analogous to `pros::Optical::get <../cpp/optical.html#get_velocity>`_.
       .. highlight:: c
       ::
 
-    optical_direction_e_t optical_get_gesture(uint8_t port);
+        optical_direction_e_t optical_get_gesture(uint8_t port);
 
    .. tab :: Example
       .. highlight:: c
@@ -427,7 +427,7 @@ Analogous to `pros::Optical::get <../cpp/optical.html#get_velocity>`_.
       .. highlight:: c
       ::
 
-    optical_gesture_s_t optical_get_gesture_raw(uint8_t port);
+        optical_gesture_s_t optical_get_gesture_raw(uint8_t port);
 
    .. tab :: Example
       .. highlight:: c
@@ -477,7 +477,7 @@ Analogous to `pros::Optical::get <../cpp/optical.html#get_velocity>`_.
       .. highlight:: c
       ::
 
-    int32_t optical_enable_gesture(uint8_t port);
+        int32_t optical_enable_gesture(uint8_t port);
 
    .. tab :: Example
       .. highlight:: c
@@ -519,7 +519,7 @@ Analogous to `pros::Optical::get <../cpp/optical.html#get_velocity>`_.
       .. highlight:: c
       ::
 
-    int32_t optical_disable_gesture(uint8_t port);
+        int32_t optical_disable_gesture(uint8_t port);
 
    .. tab :: Example
       .. highlight:: c

--- a/v5/api/c/optical.rst
+++ b/v5/api/c/optical.rst
@@ -21,7 +21,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::get <../cpp/optical.html#reset>`_.
+Analogous to `pros::Optical::reset <../cpp/optical.html#reset>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -65,7 +65,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::get <../cpp/Optical.html#set_reversed>`_.
+Analogous to `pros::Optical::set_reversed <../cpp/Optical.html#set_reversed>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -109,7 +109,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::get <../cpp/Optical.html#get_reversed>`_.
+Analogous to `pros::Optical::get_brightness <../cpp/Optical.html#get_brightness>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -152,7 +152,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::get <../cpp/Optical.html#set_position>`_.
+Analogous to `pros::Optical::get_proximity <../cpp/Optical.html#set_proximity>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -195,7 +195,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::get <../cpp/optical.html#get_position>`_.
+Analogous to `pros::Optical::get_led_pwm <../cpp/optical.html#get_led_pwm>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -238,7 +238,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::get <../cpp/optical.html#get_angle>`_.
+Analogous to `pros::Optical::get_led_pwm <../cpp/optical.html#get_led_pwm>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -280,7 +280,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::get <../cpp/optical.html#get_velocity>`_.
+Analogous to `pros::Optical::get_rgb <../cpp/optical.html#get_rgb>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -327,7 +327,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::get <../cpp/optical.html#get_velocity>`_.
+Analogous to `pros::Optical::get_raw <../cpp/optical.html#get_raw>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -376,7 +376,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::get <../cpp/optical.html#get_velocity>`_.
+Analogous to `pros::Optical::get_gesture <../cpp/optical.html#get_gesture>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -420,7 +420,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::get <../cpp/optical.html#get_velocity>`_.
+Analogous to `pros::Optical::get_gesture_raw <../cpp/optical.html#get_velocity>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -470,7 +470,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::get <../cpp/optical.html#get_velocity>`_.
+Analogous to `pros::Optical::enable_gesture <../cpp/optical.html#enable_gesture>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -512,7 +512,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::get <../cpp/optical.html#get_velocity>`_.
+Analogous to `pros::Optical::disable_gesture <../cpp/optical.html#disable_gesture>`_.
 
 .. tabs ::
    .. tab :: Prototype

--- a/v5/api/c/optical.rst
+++ b/v5/api/c/optical.rst
@@ -11,7 +11,7 @@ Functions
 =========
 
 optical_get_hue
-----------------
+---------------
 
 Get the detected color hue. This is not available if gestures
 are being detected.  Hue has a range of ``0`` ``359.999``.
@@ -21,7 +21,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::reset <../cpp/optical.html#reset>`_.
+Analogous to `pros::Optical::get_hue <../cpp/optical.html#get-hue>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -55,7 +55,7 @@ Analogous to `pros::Optical::reset <../cpp/optical.html#reset>`_.
 ----
 
 optical_get_saturation
-----------------
+----------------------
 
 Gets the detected color saturation. This is not available if gestures
 are being detected.  Saturation has a range ``0`` ``1.0``.
@@ -65,7 +65,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::set_reversed <../cpp/Optical.html#set_reversed>`_.
+Analogous to `pros::Optical::get_saturation <../cpp/Optical.html#get-saturation>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -99,7 +99,7 @@ Analogous to `pros::Optical::set_reversed <../cpp/Optical.html#set_reversed>`_.
 ----
 
 optical_get_brightness
-----------------
+----------------------
 
 Get the detected color brightness. This is not available if gestures
 are being detected.  Brightness values are in range ``0`` ``1.0``.
@@ -109,7 +109,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::get_brightness <../cpp/Optical.html#get_brightness>`_.
+Analogous to `pros::Optical::get_brightness <../cpp/Optical.html#get-brightness>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -142,7 +142,7 @@ Analogous to `pros::Optical::get_brightness <../cpp/Optical.html#get_brightness>
 ----
 
 optical_get_proximity(uint8_t port)
-----------------
+-----------------------------------
 
 Get the detected proximity value. This function is not available if gestures 
 are being detected. Proximity has a range of ``0`` ``255``.
@@ -152,7 +152,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::get_proximity <../cpp/Optical.html#set_proximity>`_.
+Analogous to `pros::Optical::get_proximity <../cpp/Optical.html#get-proximity>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -186,7 +186,7 @@ Analogous to `pros::Optical::get_proximity <../cpp/Optical.html#set_proximity>`_
 ----
 
 optical_set_led_pwm
-----------------
+-------------------
 
 Sets the pwm value of the White LED.  Valid values are in the range ``0`` ``100``.
 
@@ -195,7 +195,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::get_led_pwm <../cpp/optical.html#get_led_pwm>`_.
+Analogous to `pros::Optical::set_led_pwm <../cpp/optical.html#set-led-pwm>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -229,7 +229,7 @@ Analogous to `pros::Optical::get_led_pwm <../cpp/optical.html#get_led_pwm>`_.
 ----
 
 optical_get_led_pwm
-----------------
+-------------------
 
 Get the pwm value of the White LED.  PWM value ranges from ``0`` to ``100``.
 
@@ -238,7 +238,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::get_led_pwm <../cpp/optical.html#get_led_pwm>`_.
+Analogous to `pros::Optical::get_led_pwm <../cpp/optical.html#get-led-pwm>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -271,7 +271,7 @@ Analogous to `pros::Optical::get_led_pwm <../cpp/optical.html#get_led_pwm>`_.
 ----
 
 optical_get_rgb
-----------------
+---------------
 
 Get the processed RGBC data from the sensor.
 
@@ -280,7 +280,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::get_rgb <../cpp/optical.html#get_rgb>`_.
+Analogous to `pros::Optical::get_rgb <../cpp/optical.html#get-rgb>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -327,7 +327,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::get_raw <../cpp/optical.html#get_raw>`_.
+Analogous to `pros::Optical::get_raw <../cpp/optical.html#get-raw>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -365,7 +365,7 @@ Analogous to `pros::Optical::get_raw <../cpp/optical.html#get_raw>`_.
 ----
 
 optical_get_gesture
-----------------
+-------------------
 
 Get the most recent gesture data from the sensor.
 
@@ -376,7 +376,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::get_gesture <../cpp/optical.html#get_gesture>`_.
+Analogous to `pros::Optical::get_gesture <../cpp/optical.html#get-gesture>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -411,7 +411,7 @@ Analogous to `pros::Optical::get_gesture <../cpp/optical.html#get_gesture>`_.
 ----
 
 optical_get_gesture_raw
-----------------
+-----------------------
 
 Get the most recent raw gesture data from the sensor.
 
@@ -420,7 +420,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::get_gesture_raw <../cpp/optical.html#get_velocity>`_.
+Analogous to `pros::Optical::get_gesture_raw <../cpp/optical.html#get-gesture-raw>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -461,7 +461,7 @@ Analogous to `pros::Optical::get_gesture_raw <../cpp/optical.html#get_velocity>`
 ----
 
 optical_enable_gesture
-----------------
+----------------------
 
 Enable gesture detection on the sensor.
 
@@ -470,7 +470,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::enable_gesture <../cpp/optical.html#enable_gesture>`_.
+Analogous to `pros::Optical::enable_gesture <../cpp/optical.html#enable-gesture>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -503,7 +503,7 @@ Analogous to `pros::Optical::enable_gesture <../cpp/optical.html#enable_gesture>
 ----
 
 optical_disable_gesture
-----------------
+-----------------------
 
 Disable gesture detection on the sensor.
 
@@ -512,7 +512,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Optical Sensor.
 
-Analogous to `pros::Optical::disable_gesture <../cpp/optical.html#disable_gesture>`_.
+Analogous to `pros::Optical::disable_gesture <../cpp/optical.html#disable-gesture>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -548,7 +548,7 @@ Data Structures
 ===============
 
 optical_rgb_s_t
------------------
+---------------
 
 The RGB and Brightness values for the optical sensor.
 
@@ -562,7 +562,7 @@ The RGB and Brightness values for the optical sensor.
   } optical_raw_s_t;
 
 optical_raw_s_t
------------------
+---------------
 
 The RGB and clear values for the optical sensor.
 
@@ -576,7 +576,7 @@ The RGB and clear values for the optical sensor.
   } optical_raw_s_t;
 
 optical_gesture_s_t
------------------
+-------------------
 
 This structure contains the raw gesture data.
 

--- a/v5/api/c/rotation.rst
+++ b/v5/api/c/rotation.rst
@@ -20,7 +20,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Rotation Sensor.
 
-Analogous to `pros::Rotation::get <../cpp/rotation.html#reset>`_.
+Analogous to `pros::Rotation::reset <../cpp/rotation.html#reset>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -65,14 +65,14 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Rotation Sensor.
 
-Analogous to `pros::Rotation::get <../cpp/rotation.html#set_position>`_.
+Analogous to `pros::Rotation::set_position <../cpp/rotation.html#set_position>`_.
 
 .. tabs ::
    .. tab :: Prototype
       .. highlight:: c
       ::
 
-    int32_t rotation_set_position(uint8_t port, uint32_t position);
+        int32_t rotation_set_position(uint8_t port, uint32_t position);
 
    .. tab :: Example
       .. highlight:: c
@@ -110,14 +110,14 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Rotation Sensor.
 
-Analogous to `pros::Rotation::get <../cpp/rotation.html#set_position>`_.
+Analogous to `pros::Rotation::set_position <../cpp/rotation.html#set_position>`_.
 
 .. tabs ::
    .. tab :: Prototype
       .. highlight:: c
       ::
 
-    int32_t rotation_set_position(uint8_t port, uint32_t position);
+        int32_t rotation_set_position(uint8_t port, uint32_t position);
 
    .. tab :: Example
       .. highlight:: c
@@ -156,14 +156,14 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as a Rotation Sensor.
 
-Analogous to `pros::Rotation::get <../cpp/rotation.html#get_position>`_.
+Analogous to `pros::Rotation::get_position <../cpp/rotation.html#get_position>`_.
 
 .. tabs ::
    .. tab :: Prototype
       .. highlight:: c
       ::
 
-    int32_t rotation_get_position(uint8_t port);
+       int32_t rotation_get_position(uint8_t port);
 
    .. tab :: Example
       .. highlight:: c
@@ -198,14 +198,14 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as a Rotation Sensor.
 
-Analogous to `pros::Rotation::get <../cpp/rotation.html#get_velocity>`_.
+Analogous to `pros::Rotation::get_velocity <../cpp/rotation.html#get_velocity>`_.
 
 .. tabs ::
    .. tab :: Prototype
       .. highlight:: c
       ::
 
-    int32_t rotation_get_velocity(uint8_t port);
+        int32_t rotation_get_velocity(uint8_t port);
 
    .. tab :: Example
       .. highlight:: c
@@ -241,14 +241,14 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as a Rotation Sensor.
 
-Analogous to `pros::Rotation::get <../cpp/rotation.html#get_angle>`_.
+Analogous to `pros::Rotation::get_angle <../cpp/rotation.html#get_angle>`_.
 
 .. tabs ::
    .. tab :: Prototype
       .. highlight:: c
       ::
 
-    int32_t rotation_get_angle(uint8_t port);
+        int32_t rotation_get_angle(uint8_t port);
 
    .. tab :: Example
       .. highlight:: c
@@ -282,6 +282,8 @@ This function uses the following values of ``errno`` when an error state is reac
 
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Rotation Sensor.
+
+Analogous to `pros::Rotation::set_reversed <../cpp/rotation.html#set_reversed>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -326,6 +328,8 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Rotation Sensor.
 
+Analogous to `pros::Rotation::reverse <../cpp/rotation.html#reverse>`_.
+
 .. tabs ::
    .. tab :: Prototype
       .. highlight:: c
@@ -368,6 +372,8 @@ This function uses the following values of ``errno`` when an error state is reac
 
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Rotation Sensor.
+
+Analogous to `pros::Rotation::get_reversed <../cpp/rotation.html#get_reversed>`_.
 
 .. tabs ::
    .. tab :: Prototype

--- a/v5/api/c/rotation.rst
+++ b/v5/api/c/rotation.rst
@@ -1,9 +1,9 @@
 .. highlight:: c
    :linenothreshold: 5
 
-==================
+=========================
 VEX Rotation Sensor C API
-==================
+=========================
 
 .. contents:: :local:
 
@@ -11,7 +11,7 @@ Functions
 =========
 
 rotation_reset
-----------------
+--------------
 
 Reset the current absolute position to be the same as the Rotation Sensor angle.
 
@@ -56,7 +56,7 @@ Analogous to `pros::Rotation::reset <../cpp/rotation.html#reset>`_.
 ----
 
 rotation_set_position
-----------------
+---------------------
 
 Set the Rotation sensor to a desired rotation value.
 
@@ -65,7 +65,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Rotation Sensor.
 
-Analogous to `pros::Rotation::set_position <../cpp/rotation.html#set_position>`_.
+Analogous to `pros::Rotation::set_position <../cpp/rotation.html#set-position>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -100,8 +100,9 @@ Analogous to `pros::Rotation::set_position <../cpp/rotation.html#set_position>`_
 **Returns:** ``1``  if operation successful or ``PROS_ERR`` if the operation failed, setting ``errno``.
 
 ----
+
 rotation_reset_position
-----------------
+-----------------------
 
 Reset the Rotation Sensor position to 0.
 
@@ -110,14 +111,14 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Rotation Sensor.
 
-Analogous to `pros::Rotation::set_position <../cpp/rotation.html#set_position>`_.
+Analogous to `pros::Rotation::reset_position <../cpp/rotation.html#reset-position>`_.
 
 .. tabs ::
    .. tab :: Prototype
       .. highlight:: c
       ::
 
-        int32_t rotation_set_position(uint8_t port, uint32_t position);
+        int32_t rotation_reset_position(uint8_t port);
 
    .. tab :: Example
       .. highlight:: c
@@ -139,7 +140,6 @@ Analogous to `pros::Rotation::set_position <../cpp/rotation.html#set_position>`_
  Parameters
 ============ =================================================================================================================
  port         The V5 port number from (1-21)
- position     The desired position to be set in terms of hundreths of ticks
 ============ =================================================================================================================
 
 **Returns:** ``1``  if operation successful or ``PROS_ERR`` if the operation failed, setting ``errno``.
@@ -147,7 +147,7 @@ Analogous to `pros::Rotation::set_position <../cpp/rotation.html#set_position>`_
 ----
 
 rotation_get_position
-----------------
+---------------------
 
 Get the Rotation Sensor's current position in centidegrees
 
@@ -156,7 +156,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as a Rotation Sensor.
 
-Analogous to `pros::Rotation::get_position <../cpp/rotation.html#get_position>`_.
+Analogous to `pros::Rotation::get_position <../cpp/rotation.html#get-position>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -189,7 +189,7 @@ Analogous to `pros::Rotation::get_position <../cpp/rotation.html#get_position>`_
 ----
 
 rotation_get_velocity
-----------------
+---------------------
 
 Get the Rotation Sensor's current velocity in centidegrees per second
 
@@ -198,7 +198,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as a Rotation Sensor.
 
-Analogous to `pros::Rotation::get_velocity <../cpp/rotation.html#get_velocity>`_.
+Analogous to `pros::Rotation::get_velocity <../cpp/rotation.html#get-velocity>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -232,7 +232,7 @@ Analogous to `pros::Rotation::get_velocity <../cpp/rotation.html#get_velocity>`_
 
 
 rotation_get_angle
-----------------
+------------------
 
 Get the Rotation Sensor's current position in centidegrees
 
@@ -241,7 +241,7 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as a Rotation Sensor.
 
-Analogous to `pros::Rotation::get_angle <../cpp/rotation.html#get_angle>`_.
+Analogous to `pros::Rotation::get_angle <../cpp/rotation.html#get-angle>`_.
 
 .. tabs ::
    .. tab :: Prototype
@@ -274,7 +274,7 @@ Analogous to `pros::Rotation::get_angle <../cpp/rotation.html#get_angle>`_.
 ----
 
 rotation_set_reversed
-~~~~~~~~~
+---------------------
 
 Reverse the Rotation Sensor's direction
 
@@ -283,14 +283,14 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Rotation Sensor.
 
-Analogous to `pros::Rotation::set_reversed <../cpp/rotation.html#set_reversed>`_.
+Analogous to `pros::Rotation::set_reversed <../cpp/rotation.html#set-reversed>`_.
 
 .. tabs ::
    .. tab :: Prototype
       .. highlight:: c
       ::
 
-        int32_t rotation_reverse(uint8_t port)
+        int32_t rotation_set_reversed(uint8_t port)
 
    .. tab :: Example
       .. highlight:: c
@@ -319,7 +319,7 @@ Analogous to `pros::Rotation::set_reversed <../cpp/rotation.html#set_reversed>`_
 ----
 
 rotation_reverse
-~~~~~~~~~
+----------------
 
 Reverses the rotational sensor's positive counterclockwise/clockwise direction.
 
@@ -364,7 +364,7 @@ Analogous to `pros::Rotation::reverse <../cpp/rotation.html#reverse>`_.
 ----
 
 rotation_get_reversed
-~~~~~~~~~
+---------------------
 
 Get the Rotation Sensor's reversed flag
 
@@ -373,14 +373,14 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Rotation Sensor.
 
-Analogous to `pros::Rotation::get_reversed <../cpp/rotation.html#get_reversed>`_.
+Analogous to `pros::Rotation::get_reversed <../cpp/rotation.html#get-reversed>`_.
 
 .. tabs ::
    .. tab :: Prototype
       .. highlight:: c
       ::
 
-        int32_t rotation_reverse(uint8_t port)
+        int32_t rotation_get_reverse(uint8_t port)
 
    .. tab :: Example
       .. highlight:: c

--- a/v5/api/cpp/optical.rst
+++ b/v5/api/cpp/optical.rst
@@ -278,7 +278,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ============ =================================================================================================================
  Parameters
 ============ =================================================================================================================
- value        The value to set the LED from (0-100)
+ port         The V5 port number from 1-21
 ============ =================================================================================================================
 
 **Returns:** Optical sensor's LED PWM value or PROS_ERR if the operation failed, setting ``errno``.
@@ -324,7 +324,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ============ =================================================================================================================
  Parameters
 ============ =================================================================================================================
- value        The value to set the LED from (0-100)
+ port         The V5 port number from 1-21
 ============ =================================================================================================================
 
 **Returns:** A struct of RGB values from the Optical Sensor or PROS_ERR if the operation failed, setting ``errno``.
@@ -370,7 +370,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ============ =================================================================================================================
  Parameters
 ============ =================================================================================================================
- value        The value to set the LED from (0-100)
+ port         The V5 port number from 1-21
 ============ =================================================================================================================
 
 **Returns:** A struct of the raw rgb values from the Optical Sensor or PROS_ERR if the operation failed, setting ``errno``.
@@ -413,7 +413,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ============ =================================================================================================================
  Parameters
 ============ =================================================================================================================
- value        The value to set the LED from (0-100)
+ port         The V5 port number from 1-21
 ============ =================================================================================================================
 
 **Returns:** The direction of the most recent gesture from the Optical Sensor or PROS_ERR if the operation failed, 
@@ -463,7 +463,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ============ =================================================================================================================
  Parameters
 ============ =================================================================================================================
- value        The value to set the LED from (0-100)
+ port         The V5 port number from 1-21
 ============ =================================================================================================================
 
 **Returns:** A struct of the raw gesture values from the Optical Sensor or PROS_ERR if the operation failed, setting ``errno``.
@@ -504,7 +504,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ============ =================================================================================================================
  Parameters
 ============ =================================================================================================================
- value        The value to set the LED from (0-100)
+ port         The V5 port number from 1-21
 ============ =================================================================================================================
 
 **Returns:** ``1`` if operation was successful or PROS_ERR if the operation failed, setting ``errno``.
@@ -545,7 +545,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ============ =================================================================================================================
  Parameters
 ============ =================================================================================================================
- value        The value to set the LED from (0-100)
+ port         The V5 port number from 1-21
 ============ =================================================================================================================
 
 **Returns:** ``1`` if operation was successful or PROS_ERR if the operation failed, setting ``errno``.
@@ -586,7 +586,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ============ =================================================================================================================
  Parameters
 ============ =================================================================================================================
- value        The value to set the LED from (0-100)
+ port         The V5 port number from 1-21
 ============ =================================================================================================================
 
 **Returns:** The port number of the Optical Sensor or PROS_ERR if the operation failed, setting ``errno``.

--- a/v5/api/cpp/optical.rst
+++ b/v5/api/cpp/optical.rst
@@ -8,7 +8,7 @@ VEX Optical Sensor C++ API
 .. contents:: :local:
 
 pros::Optical
-============
+=============
 
 Constructor(s)
 --------------

--- a/v5/api/cpp/optical.rst
+++ b/v5/api/cpp/optical.rst
@@ -75,7 +75,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ============ =================================================================================================================
  Parameters
 ============ =================================================================================================================
-
+ port         The V5 port number from 1-21
 ============ =================================================================================================================
 
 **Returns:** The hue value the Optical sensor sees or PROS_ERR if the operation failed, setting ``errno``.
@@ -116,7 +116,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ============ =================================================================================================================
  Parameters
 ============ =================================================================================================================
-
+ port         The V5 port number from 1-21
 ============ =================================================================================================================
 
 **Returns:** The saturation value of the Optical sensor or PROS_ERR if the operation failed, setting ``errno``.
@@ -157,7 +157,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ============ =================================================================================================================
  Parameters
 ============ =================================================================================================================
- 
+ port         The V5 port number from 1-21
 ============ =================================================================================================================
 
 **Returns:** Optical sensor's brightness value or PROS_ERR if the operation failed, setting ``errno``.
@@ -196,7 +196,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ============ =================================================================================================================
  Parameters
 ============ =================================================================================================================
- 
+  port         The V5 port number from 1-21
 ============ =================================================================================================================
 
 **Returns:** Optical sensor's proximity value or PROS_ERR if the operation failed, setting ``errno``.
@@ -278,7 +278,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ============ =================================================================================================================
  Parameters
 ============ =================================================================================================================
-
+ value        The value to set the LED from (0-100)
 ============ =================================================================================================================
 
 **Returns:** Optical sensor's LED PWM value or PROS_ERR if the operation failed, setting ``errno``.
@@ -324,7 +324,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ============ =================================================================================================================
  Parameters
 ============ =================================================================================================================
-
+ value        The value to set the LED from (0-100)
 ============ =================================================================================================================
 
 **Returns:** A struct of RGB values from the Optical Sensor or PROS_ERR if the operation failed, setting ``errno``.
@@ -370,7 +370,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ============ =================================================================================================================
  Parameters
 ============ =================================================================================================================
-
+ value        The value to set the LED from (0-100)
 ============ =================================================================================================================
 
 **Returns:** A struct of the raw rgb values from the Optical Sensor or PROS_ERR if the operation failed, setting ``errno``.
@@ -413,7 +413,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ============ =================================================================================================================
  Parameters
 ============ =================================================================================================================
-
+ value        The value to set the LED from (0-100)
 ============ =================================================================================================================
 
 **Returns:** The direction of the most recent gesture from the Optical Sensor or PROS_ERR if the operation failed, 
@@ -463,7 +463,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ============ =================================================================================================================
  Parameters
 ============ =================================================================================================================
-
+ value        The value to set the LED from (0-100)
 ============ =================================================================================================================
 
 **Returns:** A struct of the raw gesture values from the Optical Sensor or PROS_ERR if the operation failed, setting ``errno``.
@@ -504,7 +504,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ============ =================================================================================================================
  Parameters
 ============ =================================================================================================================
-
+ value        The value to set the LED from (0-100)
 ============ =================================================================================================================
 
 **Returns:** ``1`` if operation was successful or PROS_ERR if the operation failed, setting ``errno``.
@@ -545,7 +545,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ============ =================================================================================================================
  Parameters
 ============ =================================================================================================================
-
+ value        The value to set the LED from (0-100)
 ============ =================================================================================================================
 
 **Returns:** ``1`` if operation was successful or PROS_ERR if the operation failed, setting ``errno``.
@@ -586,7 +586,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ============ =================================================================================================================
  Parameters
 ============ =================================================================================================================
-
+ value        The value to set the LED from (0-100)
 ============ =================================================================================================================
 
 **Returns:** The port number of the Optical Sensor or PROS_ERR if the operation failed, setting ``errno``.

--- a/v5/api/cpp/rotation.rst
+++ b/v5/api/cpp/rotation.rst
@@ -129,7 +129,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ----
 
 set_reversed
-~~~~~~~~~
+~~~~~~~~~~~~
 
 Reverse the Rotation Sensor's direction
 
@@ -143,7 +143,7 @@ This function uses the following values of ``errno`` when an error state is reac
       .. highlight:: cpp
       ::
 
-        std::int32_t reverse(bool value)
+        std::int32_t set_reverse(bool value)
 
    .. tab :: Example
       .. highlight:: cpp
@@ -172,7 +172,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ----
 
 set_position
-~~~~~~~~~
+~~~~~~~~~~~~
 
 Set the Rotation sensor to a desired rotation value.
 
@@ -186,7 +186,7 @@ This function uses the following values of ``errno`` when an error state is reac
       .. highlight:: cpp
       ::
 
-        std::int32_t get_position(std::uint32_t position)
+        std::int32_t set_position(std::uint32_t position)
 
    .. tab :: Example
       .. highlight:: cpp
@@ -213,7 +213,7 @@ This function uses the following values of ``errno`` when an error state is reac
 **Returns:** Rotation sensor position or PROS_ERR if the operation failed, setting ``errno``.
 
 get_position
-~~~~~~~~~
+~~~~~~~~~~~~
 
 Get the Rotation Sensor's current position in centidegrees
 
@@ -254,7 +254,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ----
 
 get_velocity
-~~~~~~~~~
+~~~~~~~~~~~~
 
 Get the Rotation Sensor's current velocity in centidegrees per second
 


### PR DESCRIPTION
Changes:
-Fixed syntax highlighting and analogous functions on C pages for optical and rotation sensors.
![image](https://user-images.githubusercontent.com/54247087/98457809-ccb22e00-2158-11eb-8efb-0957a2093493.png)
-Fixed everything under get_hue for the optical C++ pages not showing up.
![image](https://user-images.githubusercontent.com/54247087/98457884-1438ba00-2159-11eb-9943-d6a8e1a4efe9.png)
