### PR TITLE
Clarifications to Rotation Sensor's get_angle Documentation

### DIFF
--- a/v5/api/c/rotation.rst
+++ b/v5/api/c/rotation.rst
@@ -234,7 +234,7 @@ Analogous to `pros::Rotation::get_velocity <../cpp/rotation.html#get-velocity>`_
 rotation_get_angle
 ------------------
 
-Get the Rotation Sensor's current position in centidegrees
+Get the Rotation Sensor's current angle in centidegrees (0-36000)
 
 This function uses the following values of ``errno`` when an error state is reached:
 

--- a/v5/api/cpp/rotation.rst
+++ b/v5/api/cpp/rotation.rst
@@ -297,7 +297,7 @@ This function uses the following values of ``errno`` when an error state is reac
 get_angle
 ~~~~~~~~~
 
-Get the Rotation Sensor's current position in centidegrees
+Get the Rotation Sensor's current angle in centidegrees (0-36000)
 
 This function uses the following values of ``errno`` when an error state is reached:
 
@@ -331,7 +331,7 @@ This function uses the following values of ``errno`` when an error state is reac
  port         The V5 port number from (1-21)
 ============ =================================================================================================================
 
-**Returns:** Rotation sensor angle or PROS_ERR if the operation failed, setting ``errno``.
+**Returns:** Rotation sensor's current angle from 0 to 36000 or ``PROS_ERR`` if the operation failed, setting ``errno``.
 
 ----
 


### PR DESCRIPTION
Added clarifications to get_angle as to what centidegrees entails to reflect kernel header documentation changes as detailed in the attached issue (#203).