### PR TITLE
Remove pros-cli-v5 from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ Sphinx==1.8.5
 sphinx_tabs==1.1.10
 ablog==0.9.4
 sphinx-click==2.0.1
-pros-cli-v5
 click

--- a/v5/cli/conductor.rst
+++ b/v5/cli/conductor.rst
@@ -129,12 +129,3 @@ concisely, any header files which weren't added by a template are included.
 
 For advanced usage of creating templates, you can modify the ``Makefile`` with
 your own custom arguments to ``pros conduct create-template``
-
-Reference
-=========
-.. click:: pros.cli.conductor:conductor
-	:prog: prosv5 conduct
-	:show-nested:
-
-.. click:: pros.cli.conductor_utils:create_template
-	:prog: prosv5 conduct create-template


### PR DESCRIPTION
Removes pros-cli-v5 from requirements.txt.

closes #122 