### PR TITLE
CPP create_color_code default parameter documentation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ Sphinx==1.8.5
 sphinx_tabs==1.1.10
 ablog==0.9.4
 sphinx-click==2.0.1
-pros-cli-v5
 click

--- a/v5/api/cpp/vision.rst
+++ b/v5/api/cpp/vision.rst
@@ -184,9 +184,9 @@ reached:
 ============ ===============================================================
  sig_id1      The first signature id [1-7] to add to the color code
  sig_id2      The second signature id [1-7] to add to the color code
- sig_id3      The third signature id [1-7] to add to the color code
- sig_id4      The fourth signature id [1-7] to add to the color code
- sig_id5      The fifth signature id [1-7] to add to the color code
+ sig_id3      The third signature id [1-7] to add to the color code (0 by default if none provided)
+ sig_id4      The fourth signature id [1-7] to add to the color code (0 by default if none provided)
+ sig_id5      The fifth signature id [1-7] to add to the color code (0 by default if none provided)
 ============ ===============================================================
 
 **Returns:** A ``pros::vision_color_code_t`` object containing the color code information.

--- a/v5/cli/conductor.rst
+++ b/v5/cli/conductor.rst
@@ -129,12 +129,3 @@ concisely, any header files which weren't added by a template are included.
 
 For advanced usage of creating templates, you can modify the ``Makefile`` with
 your own custom arguments to ``pros conduct create-template``
-
-Reference
-=========
-.. click:: pros.cli.conductor:conductor
-	:prog: prosv5 conduct
-	:show-nested:
-
-.. click:: pros.cli.conductor_utils:create_template
-	:prog: prosv5 conduct create-template


### PR DESCRIPTION
This PR Documents the default parameters for create_color_code in the cpp page. 

Note: We should also update the kernel header files when we work on PROS 4 for this, as the switch to doxygen would make this somewhat necessary so the docs show the default params properly.