### PR TITLE
Added documentation for create_color_code's default params

### DIFF
--- a/v5/api/cpp/vision.rst
+++ b/v5/api/cpp/vision.rst
@@ -184,9 +184,9 @@ reached:
 ============ ===============================================================
  sig_id1      The first signature id [1-7] to add to the color code
  sig_id2      The second signature id [1-7] to add to the color code
- sig_id3      The third signature id [1-7] to add to the color code
- sig_id4      The fourth signature id [1-7] to add to the color code
- sig_id5      The fifth signature id [1-7] to add to the color code
+ sig_id3      The third signature id [1-7] to add to the color code (0 by default if none provided)
+ sig_id4      The fourth signature id [1-7] to add to the color code (0 by default if none provided)
+ sig_id5      The fifth signature id [1-7] to add to the color code (0 by default if none provided)
 ============ ===============================================================
 
 **Returns:** A ``pros::vision_color_code_t`` object containing the color code information.


### PR DESCRIPTION
This PR documents the default parameters for create_color_code in the cpp page.

Note: We should also update the kernel header files when we work on PROS 4 for this, as the switch to doxygen would make this somewhat necessary so the docs show the default params properly.