### PR TITLE
Change step number on the notice to line up with the main tutorial

### DIFF
--- a/v5/getting-started/macos.rst
+++ b/v5/getting-started/macos.rst
@@ -16,7 +16,7 @@ The recommended method of installing PROS 3 for macOS involves using `Homebrew <
 5. (Optional) If you are planning to use the Vision Sensor, you will likely need to also install the VEX Vision Utility to set up signatures. Run :code:`brew install vcs-vision` to do this. Once installed, you'll be able to run the program by looking for "vcs_vision" in Spotlight.
 6. That's it! You can now start using PROS 3.
 
-.. note:: If you do not want to use the PROS Editor, and instead intend to use only the PROS CLI, substitute the command in step 3 with the following: :code:`brew install pros-cli`.
+.. note:: If you do not want to use the PROS Editor, and instead intend to use only the PROS CLI, substitute the command in step 4 with the following: :code:`brew install pros-cli`.
 
 Other Methods
 -------------


### PR DESCRIPTION
On [https://pros.cs.purdue.edu/v5/getting-started/macos.html](https://pros.cs.purdue.edu/v5/getting-started/macos.html), the first note reads that you should replace step 3 with `brew install pros-cli`. 

However step 3 currently says to add the pros homebrew repository. As far as I can tell you need that to install the pros cli, and step 4 which installs the pros editor would be the command that is replaced.