### PR TITLE
Remove 404 "PROS for V5" repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![Build Status](https://dev.azure.com/purdue-acm-sigbots/Docs/_apis/build/status/purduesigbots.pros-docs?branchName=master)](https://dev.azure.com/purdue-acm-sigbots/Docs/_build/latest?definitionId=2&branchName=master)
 
-This repository hosts the documentation for [PROS for V5](https://github.com/purduesigbots/pros3)
-and [PROS for Cortex](https://github.com/purduesigbots/pros). These docs are hosted
+This repository hosts the documentation for [PROS for V5 and Cortex](https://github.com/purduesigbots/pros). These docs are hosted
 at https://pros.cs.purdue.edu/.
 
 ## How are these docs built?


### PR DESCRIPTION
Currently the README.md still contains a broken link to https://github.com/purduesigbots/pros3, the old V5 repository. As the two have since then been merged into https://github.com/purduesigbots/pros, I've gone ahead and removed the outdated reference.