### PR TITLE
Fix set_eraser referencing the wrong prototype

### DIFF
--- a/v5/api/cpp/screen.rst
+++ b/v5/api/cpp/screen.rst
@@ -61,7 +61,7 @@ Set the eraser color for subsequent graphics operations
       .. highlight:: cpp
       ::
 
-        void set_pen(const std::uint32_t color);
+        void set_eraser(const std::uint32_t color);
 
    .. tab :: Example
       .. highlight:: cpp


### PR DESCRIPTION
Seems like there was a bit of a typo in the new Screen API documentation, as ``set_eraser`` has ``set_pen`` in the Prototype panel.