### PR TITLE
Fix typo in example for ext_adi_pin_mode

### DIFF
--- a/v5/api/c/adi_ext.rst
+++ b/v5/api/c/adi_ext.rst
@@ -723,7 +723,7 @@ This function uses the following values of ``errno`` when an error state is reac
         #define ANALOG_SENSOR_PORT 1
 
         void initialize() {
-          ext_adi_pin_mode(ANALOG_SENSOR_PORT, INPUT_ANALOG);
+          ext_adi_pin_mode(ADI_EXPANDER_PORT, ANALOG_SENSOR_PORT, INPUT_ANALOG);
         }
 
 ============ =================================================================================================================


### PR DESCRIPTION
The example documentation for ext_adi_pin_mode was missing the smart port parameter. This PR fixes that.

- Added ADI_EXPANDER_PORT parameter to example usage of ext_adi_pin_mode.