### PR TITLE
Added `task_get_current` to the C and C++ docs

### DIFF
--- a/v5/api/c/rtos.rst
+++ b/v5/api/c/rtos.rst
@@ -511,6 +511,40 @@ Analogous to `pros::Task::get_count <../cpp/rtos.html#get-count>`_.
 
 ----
 
+task_get_current
+-------------
+
+Get a handle to the task which called this function.
+
+Analogous to `pros::Task::get_current <../cpp/rtos.html#current>`_.
+
+.. tabs ::
+   .. tab :: Prototype
+      .. highlight:: c
+      ::
+
+          task_t task_get_current ( void )
+
+   .. tab :: Example
+      .. highlight:: c
+      ::
+
+        void my_task_fn(void* param) {
+          task_t this_task = task_get_current();
+          if (task_get_state(this_take) == E_TASK_STATE_RUNNING) {
+            printf("This task is currently running\n");
+          }
+          // ...
+        }
+        void initialize() {
+          task_t my_task = task_create(my_task_fn, (void*)"PROS", TASK_PRIORITY_DEFAULT,
+                                      TASK_STACK_DEPTH_DEFAULT, "My Task");
+        }
+
+**Returns:** A handle to the currently running task.
+
+----
+
 task_get_name
 -------------
 

--- a/v5/api/cpp/rtos.rst
+++ b/v5/api/cpp/rtos.rst
@@ -399,6 +399,40 @@ Analogous to `Task_get_count <../c/rtos.html#task-get-count>`_.
 
 ----
 
+current
+~~~~~~~~~
+
+Get a handle to the task which called this function.
+
+Analogous to `task_get_current <../c/rtos.html#task-get-current>`_.
+
+.. tabs ::
+   .. tab :: Prototype
+      .. highlight:: cpp
+      ::
+
+          Task pros::Task::current ( )
+
+   .. tab :: Example
+      .. highlight:: cpp
+      ::
+
+        void my_task_fn(void* param) {
+          Task this_task = pros::Task::current();
+          if (this_task.get_state() == pros::E_TASK_STATE_RUNNING) {
+            std::cout << "This task is currently running" std::endl;
+          }
+          // ...
+        }
+        void initialize() {
+          Task my_task (my_task_fn, (void*)"PROS", TASK_PRIORITY_DEFAULT,
+                        TASK_STACK_DEPTH_DEFAULT, "My Task");
+        }
+
+**Returns:** The currently running task.
+
+----
+
 get_name
 ~~~~~~~~
 


### PR DESCRIPTION
Adds both `task_get_current()` and `pros::Task::current()` to the docs to match the current API in PROS.