### PR TITLE
Correct ADI pot enum

### DIFF
--- a/v5/api/c/adi.rst
+++ b/v5/api/c/adi.rst
@@ -1461,8 +1461,8 @@ typedef enum adi_potentiometer_type_e {
 ================== ============================================================
  Value
 ================== ============================================================
- E_ADI_POT_EDR                 Configures the potentiometer as the origonal potentiometer
- E_ADI_ANALOG_OUT              Configures the potentiometer as the potentiometer
+ E_ADI_POT_EDR                 Configures the potentiometer as the original potentiometer
+ E_ADI_POT_V2                  Configures the potentiometer as the V2 potentiometer
 ================== ============================================================
 
 

--- a/v5/api/cpp/adi.rst
+++ b/v5/api/cpp/adi.rst
@@ -1700,8 +1700,8 @@ typedef enum adi_potentiometer_type_e {
 ================== ============================================================
  Value
 ================== ============================================================
- pros::E_ADI_POT_EDR                 Configures the potentiometer as the origonal potentiometer
- pros::E_ADI_ANALOG_OUT              Configures the potentiometer as the potentiometer
+ pros::E_ADI_POT_EDR                 Configures the potentiometer as the original potentiometer
+ pros::E_ADI_POT_V2                  Configures the potentiometer as the V2 potentiometer
 ================== ============================================================
 
 Typedefs


### PR DESCRIPTION
Source
https://github.com/purduesigbots/pros/blob/c2dafd2d9d007f8d22e09b7de3a9d38ad88575c4/include/pros/adi.h#L75

docs
https://github.com/purduesigbots/pros-docs/blame/master/v5/api/cpp/adi.rst#L1704

The markdown of the c++ table seems to be wrong or something because its invisible? 