### PR TITLE
Fix potentiometer version enum typo

### DIFF
--- a/v5/api/c/adi.rst
+++ b/v5/api/c/adi.rst
@@ -1461,8 +1461,8 @@ typedef enum adi_potentiometer_type_e {
 ================== ============================================================
  Value
 ================== ============================================================
- E_ADI_POT_EDR                 Configures the potentiometer as the origonal potentiometer
- E_ADI_ANALOG_OUT              Configures the potentiometer as the potentiometer
+ E_ADI_POT_EDR                 Configures the potentiometer as the original potentiometer
+ E_ADI_ANALOG_OUT              Configures the potentiometer as the new potentiometer (potentiometer V2)
 ================== ============================================================
 
 

--- a/v5/api/cpp/adi.rst
+++ b/v5/api/cpp/adi.rst
@@ -1700,8 +1700,8 @@ typedef enum adi_potentiometer_type_e {
 ================== ============================================================
  Value
 ================== ============================================================
- pros::E_ADI_POT_EDR                 Configures the potentiometer as the origonal potentiometer
- pros::E_ADI_ANALOG_OUT              Configures the potentiometer as the potentiometer
+ pros::E_ADI_POT_EDR                 Configures the potentiometer as the original potentiometer
+ pros::E_ADI_ANALOG_OUT              Configures the potentiometer as the new potentiometer (potentiometer V2)
 ================== ============================================================
 
 Typedefs


### PR DESCRIPTION
The description for the potentiometer enum value descriptions are off.