### PR TITLE
Fix return type of motor_get_voltage()

### DIFF
--- a/v5/api/c/motors.rst
+++ b/v5/api/c/motors.rst
@@ -947,7 +947,7 @@ Analogous to `pros::Motor::get_voltage <../cpp/motors.html#get-voltage>`_.
       .. highlight:: c
       ::
 
-        double motor_get_voltage ( uint8_t port )
+        int32_t motor_get_voltage ( uint8_t port )
 
    .. tab :: Example
       .. highlight:: c
@@ -956,7 +956,7 @@ Analogous to `pros::Motor::get_voltage <../cpp/motors.html#get-voltage>`_.
         void opcontrol() {
           while (true) {
             motor_move(1, controller_get_analog(E_CONTROLLER_MASTER, E_CONTROLLER_ANALOG_LEFT_Y));
-            printf("Motor Voltage: %lf\n", motor_get_voltage(1));
+            printf("Motor Voltage: %i\n", motor_get_voltage(1));
             delay(2);
           }
         }

--- a/v5/api/c/motors.rst
+++ b/v5/api/c/motors.rst
@@ -956,7 +956,7 @@ Analogous to `pros::Motor::get_voltage <../cpp/motors.html#get-voltage>`_.
         void opcontrol() {
           while (true) {
             motor_move(1, controller_get_analog(E_CONTROLLER_MASTER, E_CONTROLLER_ANALOG_LEFT_Y));
-            printf("Motor Voltage: %i\n", motor_get_voltage(1));
+            printf("Motor Voltage: %d\n", motor_get_voltage(1));
             delay(2);
           }
         }

--- a/v5/api/cpp/motors.rst
+++ b/v5/api/cpp/motors.rst
@@ -1094,7 +1094,7 @@ Analogous to `motor_get_voltage <../c/motors.html#motor-get-voltage>`_.
       .. highlight:: cpp
       ::
 
-        double pros::Motor::get_voltage ( )
+        int32_t pros::Motor::get_voltage ( )
 
    .. tab :: Example
       .. highlight:: cpp


### PR DESCRIPTION
Both the C `motor_get_voltage()` function and the C++ `Motor.get_voltage()` function claimed in the documentation to return doubles, but actually returned integers. This updates the documentation and example code to match the actual return values (based on the function declarations).