### PR TITLE
Change note in analog calibrate to reflect 10ms update intervals from the ADI sensors

### DIFF
--- a/v5/api/api-legacy.rst
+++ b/v5/api/api-legacy.rst
@@ -23,7 +23,7 @@ Do not use this function when the sensor value might be unstable
 (gyro rotation, accelerometer movement).
 
 .. note::
-   The ADI currently returns data at 50msintervals, despite the calibrate function's
+   The ADI currently returns data at 10ms intervals, despite the calibrate function's
    1ms sample rate. This sample rate was kept for the sake of being similar to PROS
    2, and increasing the sample rate would not have a tangible difference in the
    function's performance.


### PR DESCRIPTION
The note in analog calibrate said that the new update time for ADI sensors was 50ms, which was incorrect and I changed it 10 ms. 