### PR TITLE
Fix Motors CPP API move_velocity

### DIFF
--- a/v5/api/cpp/motors.rst
+++ b/v5/api/cpp/motors.rst
@@ -433,8 +433,7 @@ Analogous to `motor_move_velocity <../c/motors.html#motor-move-velocity>`_.
       .. highlight:: cpp
       ::
 
-        std::int32_t pros::Motor::move_velocity ( std::uint8_t port,
-                                                  std::int16_t velocity )
+        std::int32_t pros::Motor::move_velocity ( std::int16_t velocity )
 
    .. tab :: Example
       .. highlight:: cpp


### PR DESCRIPTION
Currently, the Motors C++ API prototype for move_velocity is this:
```
std::int32_t pros::Motor::move_velocity ( std::uint8_t port,
                                          std::int16_t velocity )
```
However, this seems to be the move_velocity prototype for the Motors C API, given that it includes a port parameter.

I fixed this, making the move_velocity prototype `std::int32_t pros::Motor::move_velocity ( std::int16_t velocity )`. This matches the parameter table below the prototype.