### PR TITLE
Fix Typo in Rotation::reset() Prototype

### DIFF
--- a/v5/api/cpp/rotation.rst
+++ b/v5/api/cpp/rotation.rst
@@ -82,7 +82,7 @@ This function uses the following values of ``errno`` when an error state is reac
       .. highlight:: cpp
       ::
 
-        std::int32_t reverse( )
+        std::int32_t reset( )
 
    .. tab :: Example
       .. highlight:: cpp


### PR DESCRIPTION
`reset` method had `reverse`'s prototype