### PR TITLE
Removed outdated toolchain through apt warning

### DIFF
--- a/v5/getting-started/linux.rst
+++ b/v5/getting-started/linux.rst
@@ -26,12 +26,9 @@ available, or if you prefer to install things manually, follow the instructions
 below.
 
 .. note::
-    For users of Debian-based distributions, be aware that the toolchain available
-    through Apt is out of date and likely will not work for PROS projects. For
-    Ubuntu users, you may see references online to a PPA by team-gcc-arm-embedded,
-    but that PPA does not seem to be updated any more. Therefore, if you are
-    using a Debian-based distribution or Ubuntu, please follow the instructions
-    below.
+    If you are using a Debian-based distribution or Ubuntu, the toolchain can be
+    installed through apt in package :code:`gcc-arm-none-eabi`. To install manually,
+    follow the instructions below.
 
 1. Download the latest version of the toolchain from `the Arm developer site <https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads>`_.
    We recommend the "Linux x86_64" release. In the rare event that you are


### PR DESCRIPTION
The toolchain available through APT is no longer significantly out of date, and this warning is no longer necessary.

As of writing, latest version available through ARM is 12.2.MPACBTI-Rel1, with official Debian packages on 12.2.Rel1 (one update behind)

ARM link: [developer.arm.com](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
APT link: [packages.deban.org](https://packages.debian.org/bookworm/gcc-arm-none-eabi) / [changelog](https://metadata.ftp-master.debian.org/changelogs//main/g/gcc-arm-none-eabi/gcc-arm-none-eabi_12.2.rel1-1_changelog)