### PR TITLE
add mainline to docs repo as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	url = https://github.com/purduesigbots/sphinx-tabs.git
 	branch = master
 	ignore = dirty
+[submodule "pros-mainline"]
+	path = pros-mainline
+	url = https://github.com/purduesigbots/pros-mainline.git


### PR DESCRIPTION
Testing to see if adding mainline to the docs repo will allow the mainline jsons to be reachable from a pros.cs.purdue.edu domain