### PR TITLE
Remove Mainline as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,6 +6,4 @@
 	url = https://github.com/purduesigbots/sphinx-tabs.git
 	branch = master
 	ignore = dirty
-[submodule "pros-mainline"]
-	path = pros-mainline
-	url = https://github.com/purduesigbots/pros-mainline.git
+


### PR DESCRIPTION
Removes mainline as a submodule. Will copy the Jsons into the repo as a next pr