### PR TITLE
Simplified Brain Screen print docs fixed

### DIFF
--- a/v5/api/c/screen.rst
+++ b/v5/api/c/screen.rst
@@ -804,7 +804,8 @@ Analogous to `pros::screen::print <../cpp/screen.html#print>`_.
  Parameters
 ============ =================================================================================================================
  txt_fmt      Text format enum that determines if the text is small, medium, or large.
- line         The one indexed line number on which to print
+ x            The x-coordinate to display the string
+ y            The y-coordinate to display the string
  text         Formatted string for printing variables and text
  ...          Optional list of arguments for the format string
 ============ =================================================================================================================

--- a/v5/api/cpp/screen.rst
+++ b/v5/api/cpp/screen.rst
@@ -796,7 +796,8 @@ Print a formatted string to the screen at a coordinate location
  Parameters
 ============ =================================================================================================================
  txt_fmt      Text format enum that determines if the text is small, medium, or large.
- line         The one indexed line number on which to print
+ x            The x-coordinate to display the string
+ y            The y-coordinate to display the string
  text         Formatted string for printing variables and text
  ...          Optional list of arguments for the format string
 ============ =================================================================================================================


### PR DESCRIPTION
Before this commit, the print function for the simplified brain screen API that was defined as
`void print(pros::text_format_e_t txt_fmt, const std::int16_t x, const std::int16_t y, const char* text, Params... args);`
Was displayed in the docs as having the parameters:
<html>
<body>
<!--StartFragment-->

Parameters |  
-- | --
txt_fmt | Text format enum that determines if the text is small, medium, or large.
line | The one indexed line number on which to print
text | Formatted string for printing variables and text
… | Optional list of arguments for the format string

<!--EndFragment-->
</body>
</html>

This was likely a result of a copy-paste, and has now been changed to:
<html>
<body>
<!--StartFragment-->

Parameters |  
-- | --
txt_fmt | Text format enum that determines if the text is small, medium, or large.
x | The x-coordinate to display the string
y | The y-coordinate to display the string
text | Formatted string for printing variables and text
… | Optional list of arguments for the format string

<!--EndFragment-->
</body>
</html>
<br>
This change affects both the C and C++ API documentation