### PR TITLE
Fix LVGL link

### DIFF
--- a/v5/extended/apix.rst
+++ b/v5/extended/apix.rst
@@ -2,7 +2,7 @@
 Extended API
 ============
 
-.. note:: Also included in the Extended API is `LVGL <https://littlevgl.com/>`_.
+.. note:: Also included in the Extended API is `LVGL <https://lvgl.io/>`_.
 
 .. note:: PROS supports a simple implementation of the 
   `POSIX clock_gettime() and clock_settime() 


### PR DESCRIPTION
Fixes the LVGL link in the docs, which currently redirects to a photo blog.