### PR TITLE
Fix typos in alias notes

### DIFF
--- a/v5/api/cpp/gps.rst
+++ b/v5/api/cpp/gps.rst
@@ -8,7 +8,7 @@ VEX GPS Sensor C++ API
 .. note:: For a pros-specific usage guide on the GPS, please check out our article
           `here <../../tutorials/topical/gps.html>`_.
 
-.. note:: ``pros::GPS`` can also be used to refer ``pros::Gps``
+.. note:: ``pros::GPS`` can also be used to refer to ``pros::Gps``
 
 .. contents:: :local:
 

--- a/v5/api/cpp/imu.rst
+++ b/v5/api/cpp/imu.rst
@@ -5,7 +5,7 @@
 VEX Inertial Sensor C++ API
 =====================
 
-.. note:: ``pros::IMU`` can also be used to refer ``pros::Imu``
+.. note:: ``pros::IMU`` can also be used to refer to ``pros::Imu``
 
 .. contents:: :local:
 


### PR DESCRIPTION
The alias notes for the GPS and IMU were missing the word "to". 