### PR TITLE
Motors C API: Add info on E_MOTOR_BRAKE_BRAKE

### DIFF
--- a/v5/api/c/motors.rst
+++ b/v5/api/c/motors.rst
@@ -1772,7 +1772,8 @@ Indicates the current 'brake mode' of the motor.
  Value
 ================================== ===========================================================
  E_MOTOR_BRAKE_COAST                Motor coasts when stopped, traditional behavior
- E_MOTOR_BRAKE_BRAKE                Motor brakes when stopped 
+ E_MOTOR_BRAKE_BRAKE                Motor short brakes when stopped by shorting (directly connecting) the motor’s positive and negative lead
+                                    https://en.m.wikipedia.org/wiki/Dynamic_braking
  E_MOTOR_BRAKE_HOLD                 Motor actively holds position when stopped 
  E_MOTOR_BRAKE_INVALID              Invalid brake mode
 ================================== ===========================================================


### PR DESCRIPTION
The Motors C++ API contains information about the E_MOTOR_BRAKE_BRAKE enum value for motor_brake_mode_e_t. However, this information is not present in the corresponding C API page. This PR (just 1 commit) just copies over the information from the C++ API page to the C API page