### PR TITLE
Motors C API: Fix faults enum documentation

### DIFF
--- a/v5/api/c/motors.rst
+++ b/v5/api/c/motors.rst
@@ -1823,10 +1823,11 @@ motor_fault_e_t
 ================================== ===========================================================
  Value
 ================================== ===========================================================
- E_MOTOR_FAULT_NO_FAULTS            No faults
- E_MOTOR_BRAKE_BRAKE                Motor brakes when stopped 
- E_MOTOR_BRAKE_HOLD                 Motor actively holds position when stopped 
- E_MOTOR_BRAKE_INVALID              Invalid brake mode
+ E_MOTOR_FAULT_NO_FAULTS                 No faults
+ E_MOTOR_FAULT_MOTOR_OVER_TEMP           Analogous to motor_is_over_temp()
+ E_MOTOR_FAULT_DRIVER_FAULT              Indicates a motor h-bridge fault
+ E_MOTOR_FAULT_OVER_CURRENT              Analogous to motor_is_over_current()
+ E_MOTOR_FAULT_DRV_OVER_CURRENT          Indicates an h-bridge over current
 ================================== ===========================================================
 
 ----


### PR DESCRIPTION
Right now, the motor_fault_e_t section in the Motors C API page looks like this:

| Value | |
|--------------------------------------------------|-------------------------- 	 
| E_MOTOR_FAULT_NO_FAULTS 	| No faults
| E_MOTOR_BRAKE_BRAKE		| Motor brakes when stopped
| E_MOTOR_BRAKE_HOLD 		| Motor actively holds position when stopped
| E_MOTOR_BRAKE_INVALID 		| Invalid brake mode

(see https://pros.cs.purdue.edu/v5/api/c/motors.html#motor-fault-e-t)

This is clearly wrong - it's mostly the brake mode enum values.

The commit in this PR changes this table to have the same content as the Motors C++ API page:

| Value | |
|---------------------------------------------------------------|----------------------------------------- 	 
| E_MOTOR_FAULT_NO_FAULTS			| No faults
| E_MOTOR_FAULT_MOTOR_OVER_TEMP	| Analogous to motor_is_over_temp()
| E_MOTOR_FAULT_DRIVER_FAULT			| Indicates a motor h-bridge fault
| E_MOTOR_FAULT_OVER_CURRENT		| Analogous to motor_is_over_current()
| E_MOTOR_FAULT_DRV_OVER_CURRENT	| Indicates an h-bridge over current