### PR TITLE
Kernel 3.8.3 Release

### DIFF
--- a/v5/_static/releases/pros-mainline.json
+++ b/v5/_static/releases/pros-mainline.json
@@ -586,5 +586,15 @@
         "supported_kernels": null,
         "target": "v5",
         "version": "3.8.2"
+    },
+    {
+        "metadata": {
+            "location": "https://pros.cs.purdue.edu/v5/_static/releases/kernel@3.8.3.zip"
+        },
+        "name": "kernel",
+        "py/object": "pros.conductor.templates.base_template.BaseTemplate",
+        "supported_kernels": null,
+        "target": "v5",
+        "version": "3.8.3"
     }
 ]

--- a/v5/api/c/imu.rst
+++ b/v5/api/c/imu.rst
@@ -1222,7 +1222,7 @@ E_IMU_STATUS_ERROR                  Used to indicate that an error state was rea
 ---
 
 imu_orientation_e_t
---------------
+-------------------
 
 Indicates IMU physical orientation.
 

--- a/v5/api/c/imu.rst
+++ b/v5/api/c/imu.rst
@@ -561,7 +561,7 @@ Analogous to `pros::Imu::get_status <../cpp/imu.html#get_status>`_.
 ---
 
 imu_get_physical_orientation
--------------------
+----------------------------
 
 Get the Inertial Sensor's physical orientation.
 

--- a/v5/api/c/imu.rst
+++ b/v5/api/c/imu.rst
@@ -560,7 +560,7 @@ Analogous to `pros::Imu::get_status <../cpp/imu.html#get_status>`_.
 
 ---
 
-imu_get_orientation
+imu_get_physical_orientation
 -------------------
 
 Get the Inertial Sensor's physical orientation.
@@ -570,14 +570,14 @@ This function uses the following values of ``errno`` when an error state is reac
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Inertial Sensor.
 
-Analogous to `pros::Imu::get_status <../cpp/imu.html#get_orientation>`_.
+Analogous to `pros::Imu::get_status <../cpp/imu.html#get_physical_orientation>`_.
 
 .. tabs ::
    .. tab :: Prototype
       .. highlight:: c
       ::
 
-        imu_orientation_e_t imu_get_orientation (uint8_t port)
+        imu_orientation_e_t imu_get_physical_orientation (uint8_t port)
 
    .. tab :: Example
       .. highlight:: c
@@ -587,7 +587,7 @@ Analogous to `pros::Imu::get_status <../cpp/imu.html#get_orientation>`_.
 
         void initialize() {
           imu_reset(IMU_PORT);
-            printf("IMU orientation %d\n", imu_get_orientation);
+            printf("IMU orientation %d\n", imu_get_physical_orientation(IMU_PORT));
 
         }
 
@@ -597,7 +597,7 @@ Analogous to `pros::Imu::get_status <../cpp/imu.html#get_orientation>`_.
  port         The V5 port number from (1-21)
 ============ =================================================================================================================
 
-**Returns:** The Inertial Sensor's orientation, or ``PROS_ERR`` if the operation failed, setting ``errno``. 
+**Returns:** The Inertial Sensor's physical orientation, or ``PROS_ERR`` if the operation failed, setting ``errno``. 
 
 ---
 

--- a/v5/api/c/imu.rst
+++ b/v5/api/c/imu.rst
@@ -561,7 +561,7 @@ Analogous to `pros::Imu::get_status <../cpp/imu.html#get_status>`_.
 ---
 
 imu_get_orientation
---------------
+-------------------
 
 Get the Inertial Sensor's physical orientation.
 

--- a/v5/api/c/imu.rst
+++ b/v5/api/c/imu.rst
@@ -521,7 +521,6 @@ This function uses the following values of ``errno`` when an error state is reac
 
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Inertial Sensor.
-- ``EAGAIN`` - The sensor is already calibrating.
 
 Analogous to `pros::Imu::get_status <../cpp/imu.html#get_status>`_.
 
@@ -558,6 +557,46 @@ Analogous to `pros::Imu::get_status <../cpp/imu.html#get_status>`_.
 ============ =================================================================================================================
 
 **Returns:** The Inertial Sensor's status code, or ``PROS_ERR`` if the operation failed, setting ``errno``. 
+
+---
+imu_get_orientation
+--------------
+
+Get the Inertial Sensor's physical orientation.
+
+This function uses the following values of ``errno`` when an error state is reached:
+
+- ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV`` - The port cannot be configured as an Inertial Sensor.
+
+Analogous to `pros::Imu::get_status <../cpp/imu.html#get_orientation>`_.
+
+.. tabs ::
+   .. tab :: Prototype
+      .. highlight:: c
+      ::
+
+        imu_orientation_e_t imu_get_orientation (uint8_t port)
+
+   .. tab :: Example
+      .. highlight:: c
+      ::
+
+        #define IMU_PORT 1
+
+        void initialize() {
+          imu_reset(IMU_PORT);
+            printf("IMU orientation %d\n", imu_get_orientation);
+
+        }
+
+============ =================================================================================================================
+ Parameters
+============ =================================================================================================================
+ port         The V5 port number from (1-21)
+============ =================================================================================================================
+
+**Returns:** The Inertial Sensor's orientation, or ``PROS_ERR`` if the operation failed, setting ``errno``. 
 
 ---
 
@@ -1180,6 +1219,33 @@ E_IMU_STATUS_ERROR                  Used to indicate that an error state was rea
 ================================== =====================================================================================
 
 ---
+
+imu_orientation_e_t
+--------------
+
+Indicates IMU physical orientation.
+
+::
+
+typedef enum imu_orientation_e {
+	E_IMU_Z_UP = 0,    // IMU has the Z axis UP (VEX Logo facing DOWN)
+	E_IMU_Z_DOWN = 1,  // IMU has the Z axis DOWN (VEX Logo facing UP)
+	E_IMU_X_UP = 2,    // IMU has the X axis UP
+	E_IMU_X_DOWN = 3,  // IMU has the X axis DOWN
+	E_IMU_Y_UP = 4,    // IMU has the Y axis UP
+	E_IMU_Y_DOWN = 5,  // IMU has the Y axis DOWN
+} imu_orientation_e_t;
+
+================================== =====================================================================================
+ Value
+================================== =====================================================================================
+E_IMU_Z_UP                          IMU has the Z axis UP (VEX Logo facing DOWN)
+E_IMU_Z_DOWN                        IMU has the Z axis DOWN (VEX Logo facing UP)
+E_IMU_X_UP                          IMU has the X axis UP
+E_IMU_X_DOWN                        IMU has the X axis DOWN 
+E_IMU_Y_UP                          IMU has the Y axis UP
+E_IMU_Y_DOWN                        IMU has the Y axis DOWN 
+================================== =====================================================================================
 
 Structures
 ==========

--- a/v5/api/c/imu.rst
+++ b/v5/api/c/imu.rst
@@ -559,6 +559,7 @@ Analogous to `pros::Imu::get_status <../cpp/imu.html#get_status>`_.
 **Returns:** The Inertial Sensor's status code, or ``PROS_ERR`` if the operation failed, setting ``errno``. 
 
 ---
+
 imu_get_orientation
 --------------
 

--- a/v5/api/cpp/imu.rst
+++ b/v5/api/cpp/imu.rst
@@ -405,7 +405,7 @@ This function uses the following values of ``errno`` when an error state is reac
 ----
 
 tare_rotation
-~~~~~~~~~
+~~~~~~~~~~~~~
 
 Resets the current reading of the Inertial Sensor's rotation to zero.
 
@@ -1094,10 +1094,10 @@ This function uses the following values of ``errno`` when an error state is reac
 
 ----
 
-get_orientation
-~~~~~~~~~~
+get_physical_orientation
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-Get the Inertial Sensor's orientation.
+Get the Inertial Sensor's physical orientation.
 
 This function uses the following values of ``errno`` when an error state is reached:
 
@@ -1109,7 +1109,7 @@ This function uses the following values of ``errno`` when an error state is reac
       .. highlight:: cpp
       ::
 
-	      pros::c::imu_orientation_e_t get_orientation( )
+	      pros::c::imu_orientation_e_t get_physical_orientation( )
 
    .. tab :: Example
       .. highlight:: cpp
@@ -1120,12 +1120,12 @@ This function uses the following values of ``errno`` when an error state is reac
         void initialize() {
         	pros::Imu imu_sensor (IMU_PORT);
 	        imu_sensor.reset();
-		printf("IMU Orinetation %d", imu_sensor.get_orientation());
+		printf("IMU Orinetation %d", imu_sensor.get_physical_orientation());
         }
 
 
 
-**Returns:** The Inertial Sensor's orientation, or ``PROS_ERR`` if the operation failed, setting ``errno``.
+**Returns:** The Inertial Sensor's physical orientation, or ``PROS_ERR`` if the operation failed, setting ``errno``.
 ----
 
 is_calibrating

--- a/v5/api/cpp/imu.rst
+++ b/v5/api/cpp/imu.rst
@@ -1058,7 +1058,6 @@ This function uses the following values of ``errno`` when an error state is reac
 
 - ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
 - ``ENODEV`` - The port cannot be configured as an Inertial Sensor.
-- ``EAGAIN`` - The sensor is already calibrating.
 
 .. tabs ::
    .. tab :: Prototype
@@ -1093,6 +1092,40 @@ This function uses the following values of ``errno`` when an error state is reac
 
 **Returns:** The Inertial Sensor's status code, or ``PROS_ERR`` if the operation failed, setting ``errno``. 
 
+----
+
+get_orientation
+~~~~~~~~~~
+
+Get the Inertial Sensor's orientation.
+
+This function uses the following values of ``errno`` when an error state is reached:
+
+- ``ENXIO`` - The given value is not within the range of V5 ports (1-21).
+- ``ENODEV`` - The port cannot be configured as an Inertial Sensor.
+
+.. tabs ::
+   .. tab :: Prototype
+      .. highlight:: cpp
+      ::
+
+	      pros::c::imu_orientation_e_t get_orientation( )
+
+   .. tab :: Example
+      .. highlight:: cpp
+      ::
+
+        #define IMU_PORT 1
+
+        void initialize() {
+        	pros::Imu imu_sensor (IMU_PORT);
+	        imu_sensor.reset();
+		printf("IMU Orinetation %d", imu_sensor.get_orientation());
+        }
+
+
+
+**Returns:** The Inertial Sensor's orientation, or ``PROS_ERR`` if the operation failed, setting ``errno``.
 ----
 
 is_calibrating

--- a/v5/releases/kernel3.8.3.rst
+++ b/v5/releases/kernel3.8.3.rst
@@ -1,0 +1,17 @@
+=========================
+PROS Kernel 3.8.3 Release
+=========================
+
+.. post:: 27 March, 2024
+   :tags: blog, kernel-release
+
+This update fixes a critical bug that prevented IMUS from reseting in kerenel 3.8.2.
+
+Changelog
+---------
+
+Features:
+ - Adds a function to get the physical orientation of the IMU
+
+Bugfixes:
+ - Fixes the IMU reset function from sometimes never returning


### PR DESCRIPTION
Adds Documentation and Template for kernel 3.8.3
Fixes the critical bug that prevented IMUs from getting reset. 
Added Get_orientation capabilities