### PR TITLE
Fix typo in Motor cpp docs

### DIFF
--- a/v5/api/cpp/motors.rst
+++ b/v5/api/cpp/motors.rst
@@ -1173,7 +1173,7 @@ Analogous to `motor_is_stopped <../c/motors.html#motor-is-stopped>`_.
       .. highlight:: cpp
       ::
 
-        std::int32_t motor_is_stopped ( )
+        std::int32_t pros::Motor::is_stopped ( )
 
    .. tab :: Example
       .. highlight:: cpp


### PR DESCRIPTION
The Motor cpp docs incorrectly stated the signature for `is_stopped` as 
```
std::int32_t motor_is_stopped ( )
```
when the correct signature is
```
std::int32_t pros::Motor::is_stopped()
```

This PR fixes that discrepancy.