### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # PROS Documentation
 
-[![Build Status](https://dev.azure.com/purdue-acm-sigbots/Docs/_apis/build/status/purduesigbots.pros-docs?branchName=master)](https://dev.azure.com/purdue-acm-sigbots/Docs/_build/latest?definitionId=2&branchName=master)
 
 This repository hosts the documentation for [PROS for V5 and Cortex](https://github.com/purduesigbots/pros). These docs are hosted
 at https://pros.cs.purdue.edu/.


### PR DESCRIPTION
#386 If Azure cloud is apparently no longer used, so this isn't needed its build status isn't needed on readme